### PR TITLE
[SKRB-148] feat: 행사 생성 API 틀 구현

### DIFF
--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -1,0 +1,28 @@
+package com.spaceclub.event.controller;
+
+import com.spaceclub.event.controller.dto.CreateEventRequest;
+import com.spaceclub.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.net.URI;
+
+@Controller
+@RequestMapping("/api/v1/event")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping
+    public ResponseEntity<Void> saveEvent(@RequestBody CreateEventRequest request) {
+        Long eventId = eventService.create(request.toEntity());
+
+        return ResponseEntity.created(URI.create("https/" + eventId)).build();
+    }
+
+}

--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -19,7 +19,7 @@ public class EventController {
     private final EventService eventService;
 
     @PostMapping
-    public ResponseEntity<Void> saveEvent(@RequestBody CreateEventRequest request) {
+    public ResponseEntity<Void> create(@RequestBody CreateEventRequest request) {
         Long eventId = eventService.create(request.toEntity());
 
         return ResponseEntity.created(URI.create("https/" + eventId)).build();

--- a/src/main/java/com/spaceclub/event/controller/dto/CreateEventRequest.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/CreateEventRequest.java
@@ -1,0 +1,11 @@
+package com.spaceclub.event.controller.dto;
+
+import com.spaceclub.event.domain.Event;
+
+public record CreateEventRequest(Long id) {
+
+    public Event toEntity() {
+        return new Event();
+    }
+
+}

--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -18,8 +19,9 @@ import java.time.LocalDateTime;
 public class Event extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @Getter
     @Column(name = "event_id")
+    @GeneratedValue
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event extends BaseTimeEntity {
 
     @Id
@@ -49,5 +49,7 @@ public class Event extends BaseTimeEntity {
     private FormInfo formInfo;
 
     private Long clubId;
+
+    public Event() {}
 
 }

--- a/src/main/java/com/spaceclub/event/repository/EventRepository.java
+++ b/src/main/java/com/spaceclub/event/repository/EventRepository.java
@@ -1,0 +1,10 @@
+package com.spaceclub.event.repository;
+
+import com.spaceclub.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+}

--- a/src/main/java/com/spaceclub/event/service/EventService.java
+++ b/src/main/java/com/spaceclub/event/service/EventService.java
@@ -1,0 +1,18 @@
+package com.spaceclub.event.service;
+
+import com.spaceclub.event.domain.Event;
+import com.spaceclub.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    public Long create(Event event) {
+        return eventRepository.save(event).getId();
+    }
+
+}


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [KRB-148](https://mapda.atlassian.net/browse/SKRB-148)
  <br>

### 🖥️ 작업 내용
- 행사 생성 repository, service, controller 틀 구현
<br>

### ✅ PR시 확인 사항
- [ ] 테스트 코드 작성
- [x] Linear History 여부
  <br>

### 📢 리뷰어 전달 사항

틀 구현을 위해 임시로 넣은 값
- `controller`의 `Location`
- `CreateEventRequest`의 파라미터, `toEntity `메서드
- `Event` 엔티티의 기본 생성자
