### PR TITLE
[SKRB-146] feat: user 도메인 생성 및 검증 로직 테스트

### DIFF
--- a/src/main/java/com/spaceclub/user/domain/Email.java
+++ b/src/main/java/com/spaceclub/user/domain/Email.java
@@ -1,0 +1,37 @@
+package com.spaceclub.user.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = PROTECTED)
+public class Email {
+
+    private static final Pattern VALID_EMAIL_ADDRESS_REGEX =
+            Pattern.compile("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,6}$", CASE_INSENSITIVE);
+
+    private String email;
+
+    public Email(String email) {
+        validate(email);
+        this.email = email;
+    }
+
+    private void validate(String email) {
+        Assert.hasText(email, "올바른 이메일을 입력해 주세요.");
+        Assert.isTrue(isValid(email), "올바른 이메일을 입력해 주세요.");
+    }
+
+    private boolean isValid(String email) {
+        return VALID_EMAIL_ADDRESS_REGEX.matcher(email).find();
+    }
+
+}

--- a/src/main/java/com/spaceclub/user/domain/PhoneNumber.java
+++ b/src/main/java/com/spaceclub/user/domain/PhoneNumber.java
@@ -1,0 +1,36 @@
+package com.spaceclub.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import java.util.regex.Pattern;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = PROTECTED)
+public class PhoneNumber {
+
+    private static final String REGEX = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$";
+
+    @Getter
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    public PhoneNumber(String phoneNumber) {
+        validatePhoneNumber(phoneNumber);
+        this.phoneNumber = phoneNumber;
+    }
+
+    private void validatePhoneNumber(String phoneNumber) {
+        Assert.hasText(phoneNumber, "올바른 전화번호를 입력해 주세요.");
+        Assert.isTrue(Pattern.matches(REGEX, phoneNumber), "올바른 전화번호를 입력해 주세요.");
+    }
+
+}
+

--- a/src/main/java/com/spaceclub/user/domain/PhoneNumber.java
+++ b/src/main/java/com/spaceclub/user/domain/PhoneNumber.java
@@ -3,7 +3,6 @@ package com.spaceclub.user.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
@@ -16,20 +15,26 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class PhoneNumber {
 
-    private static final String REGEX = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$";
+    private static final String DASH = "-";
+    private static final String BLANK = "";
+    private static final Pattern VALID_PHONE_NUMBER_REGEX =
+            Pattern.compile("^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$");
 
-    @Getter
     @Column(nullable = false)
     private String phoneNumber;
 
     public PhoneNumber(String phoneNumber) {
         validatePhoneNumber(phoneNumber);
-        this.phoneNumber = phoneNumber;
+        this.phoneNumber = eraseDash(phoneNumber);
+    }
+
+    private String eraseDash(String phoneNumber) {
+        return phoneNumber.replaceAll(DASH, BLANK);
     }
 
     private void validatePhoneNumber(String phoneNumber) {
         Assert.hasText(phoneNumber, "올바른 전화번호를 입력해 주세요.");
-        Assert.isTrue(Pattern.matches(REGEX, phoneNumber), "올바른 전화번호를 입력해 주세요.");
+        Assert.isTrue(VALID_PHONE_NUMBER_REGEX.matcher(phoneNumber).find(), "올바른 전화번호를 입력해 주세요.");
     }
 
 }

--- a/src/main/java/com/spaceclub/user/domain/Provider.java
+++ b/src/main/java/com/spaceclub/user/domain/Provider.java
@@ -1,5 +1,7 @@
 package com.spaceclub.user.domain;
 
 public enum Provider {
-    KAKAO
+
+    KAKAO,
+
 }

--- a/src/main/java/com/spaceclub/user/domain/Provider.java
+++ b/src/main/java/com/spaceclub/user/domain/Provider.java
@@ -1,0 +1,5 @@
+package com.spaceclub.user.domain;
+
+public enum Provider {
+    KAKAO
+}

--- a/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
+++ b/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
@@ -1,0 +1,43 @@
+package com.spaceclub.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = PROTECTED)
+public class RequiredInfo {
+
+    public static final int MIN_NICKNAME_LENGTH = 2;
+    public static final int MAX_NICKNAME_LENGTH = 10;
+
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Embedded
+    private PhoneNumber phoneNumber;
+
+    public RequiredInfo(String nickname, PhoneNumber phoneNumber) {
+        validate(nickname);
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+    }
+
+    private void validate(String nickname) {
+        Assert.hasText(nickname, "닉네임을 입력해 주세요.");
+        Assert.isTrue(!nickname.contains(" "), "닉네임에 공백을 포함할 수 없습니다.");
+        Assert.isTrue(isInValidRange(nickname), "닉네임은 2자 이상 10자 이하로 입력해 주세요.");
+    }
+
+    private boolean isInValidRange(String nickname) {
+        return nickname.length() >= MIN_NICKNAME_LENGTH && nickname.length() <= MAX_NICKNAME_LENGTH;
+    }
+
+}

--- a/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
+++ b/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
@@ -14,8 +14,8 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class RequiredInfo {
 
-    public static final int MIN_NICKNAME_LENGTH = 2;
-    public static final int MAX_NICKNAME_LENGTH = 10;
+    private static final int MIN_NICKNAME_LENGTH = 2;
+    private static final int MAX_NICKNAME_LENGTH = 10;
 
     @Column(nullable = false)
     private String nickname;
@@ -25,17 +25,16 @@ public class RequiredInfo {
 
     public RequiredInfo(String nickname, PhoneNumber phoneNumber) {
         validate(nickname);
-        this.nickname = nickname;
+        this.nickname = nickname.trim();
         this.phoneNumber = phoneNumber;
     }
 
     private void validate(String nickname) {
         Assert.hasText(nickname, "닉네임을 입력해 주세요.");
-        Assert.isTrue(!nickname.contains(" "), "닉네임에 공백을 포함할 수 없습니다.");
-        Assert.isTrue(isInValidRange(nickname), "닉네임은 2자 이상 10자 이하로 입력해 주세요.");
+        Assert.isTrue(isValidRange(nickname.trim()), "닉네임은 2자 이상 10자 이하로 입력해 주세요.");
     }
 
-    private boolean isInValidRange(String nickname) {
+    private boolean isValidRange(String nickname) {
         return nickname.length() >= MIN_NICKNAME_LENGTH && nickname.length() <= MAX_NICKNAME_LENGTH;
     }
 

--- a/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
+++ b/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
@@ -17,7 +17,6 @@ public class RequiredInfo {
     public static final int MIN_NICKNAME_LENGTH = 2;
     public static final int MAX_NICKNAME_LENGTH = 10;
 
-
     @Column(nullable = false)
     private String nickname;
 

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -1,0 +1,56 @@
+package com.spaceclub.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "user_id")
+    private Long userid;
+
+    @Embedded
+    private RequiredInfo requiredInfo;
+
+    @Column(nullable = false, unique = true)
+    private String oauthUserName;
+
+    @Enumerated(value = STRING)
+    private Provider provider;
+
+    @Embedded
+    private Email email;
+
+    @Lob
+    private String refreshToken;
+
+    @Builder
+    private User(
+            String nickname,
+            String phoneNumber,
+            String oauthUserName,
+            Provider provider,
+            Email email,
+            String refreshToken
+    ) {
+        this.requiredInfo = new RequiredInfo(nickname, new PhoneNumber(phoneNumber));
+        this.oauthUserName = oauthUserName;
+        this.provider = provider;
+        this.email = email;
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/test/java/com/spaceclub/user/domain/EmailTest.java
+++ b/src/test/java/com/spaceclub/user/domain/EmailTest.java
@@ -1,0 +1,43 @@
+package com.spaceclub.user.domain;
+
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+class EmailTest {
+
+    @ParameterizedTest(name = "{index}. email : {arguments}")
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 이메일이_null이거나_공백이면_예외를_발생한다(String email) {
+        // when, then
+        assertThatThrownBy(() -> new Email(email))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "{index}. email : {arguments}")
+    @ValueSource(strings = {"123", "wrongEmail", "wrongEmail@", "wrongEmail@com", "wrongEmail@com."})
+    void 이메일의_형식이_잘못되었을_경우_예외를_발생한다(String email) {
+        // when, then
+        assertThatThrownBy(() -> new Email(email))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 이메일의_형식이_올바르면_예외를_발생하지_않는다() {
+        // given
+        String validEmail = "valid@gmail.com";
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> new Email(validEmail));
+    }
+
+}

--- a/src/test/java/com/spaceclub/user/domain/EmailTest.java
+++ b/src/test/java/com/spaceclub/user/domain/EmailTest.java
@@ -16,7 +16,7 @@ class EmailTest {
     @ParameterizedTest(name = "{index}. email : {arguments}")
     @NullSource
     @ValueSource(strings = {"", " "})
-    void 이메일이_null이거나_공백이면_예외를_발생한다(String email) {
+    void 이메일이_null이거나_이메일_생성에_실패한다(String email) {
         // when, then
         assertThatThrownBy(() -> new Email(email))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -24,14 +24,14 @@ class EmailTest {
 
     @ParameterizedTest(name = "{index}. email : {arguments}")
     @ValueSource(strings = {"123", "wrongEmail", "wrongEmail@", "wrongEmail@com", "wrongEmail@com."})
-    void 이메일의_형식이_잘못되었을_경우_예외를_발생한다(String email) {
+    void 이메일의_형식이_잘못되었을_경우_이메일_생성에_실패한다(String email) {
         // when, then
         assertThatThrownBy(() -> new Email(email))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void 이메일의_형식이_올바르면_예외를_발생하지_않는다() {
+    void 이메일의_형식이_올바르면_이메일_생성에_성공한다() {
         // given
         String validEmail = "valid@gmail.com";
 

--- a/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
+++ b/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
@@ -2,10 +2,12 @@ package com.spaceclub.user.domain;
 
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,6 +38,18 @@ class PhoneNumberTest {
         // when, then
         assertThatNoException()
                 .isThrownBy(() -> new PhoneNumber(validPhoneNumber));
+    }
+
+    @Test
+    void 휴대폰_번호에_대시가_있을경우_제거_후_저장에_성공한다() {
+        // given
+        String phoneNumberWithDash = "010-1234-5678";
+
+        // when
+        PhoneNumber phoneNumber = new PhoneNumber(phoneNumberWithDash);
+
+        // then
+        assertThat(phoneNumber).isEqualTo(new PhoneNumber("01012345678"));
     }
 
 }

--- a/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
+++ b/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
@@ -17,7 +17,7 @@ class PhoneNumberTest {
     @ParameterizedTest(name = "{index}. Phone Number : {arguments}")
     @NullSource
     @ValueSource(strings = {"", " "})
-    void 휴대폰_번호가_null이거나_공백이면_예외를_발생한다(String invalidPhoneNumber) {
+    void 휴대폰_번호가_null이거나_공백이면_휴대폰_번호_생성에_실패한다(String invalidPhoneNumber) {
         // when, then
         assertThatThrownBy(() -> new PhoneNumber(invalidPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -25,7 +25,7 @@ class PhoneNumberTest {
 
     @ParameterizedTest(name = "{index}. Phone Number : {arguments}")
     @ValueSource(strings = {"1234567890, 가나다라, abcd, 01012345678900"})
-    void 휴대폰_번호의_형식이_잘못되었을_경우_예외를_발생한다(String invalidPhoneNumber) {
+    void 휴대폰_번호의_형식이_잘못되었을_경우_휴대폰_번호_생성에_실패한다(String invalidPhoneNumber) {
         // when, then
         assertThatThrownBy(() -> new PhoneNumber(invalidPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -34,7 +34,7 @@ class PhoneNumberTest {
     @ParameterizedTest(name = "{index}. Phone Number : {arguments}")
     @ValueSource(strings = {"010-1234-5678", "01012345678", "0101235678", "010-12345678", "010-123-5678",
             "011-1234-5678", "019-1234-5678"})
-    void 휴대폰_번호의_형식이_올바르면_예외를_발생하지_않는다(String validPhoneNumber) {
+    void 휴대폰_번호의_형식이_올바르면_휴대폰_번호_생성에_성공한다(String validPhoneNumber) {
         // when, then
         assertThatNoException()
                 .isThrownBy(() -> new PhoneNumber(validPhoneNumber));

--- a/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
+++ b/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
@@ -1,0 +1,41 @@
+package com.spaceclub.user.domain;
+
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+class PhoneNumberTest {
+
+    @ParameterizedTest(name = "{index}. Phone Number : {arguments}")
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void 휴대폰_번호가_null이거나_공백이면_예외를_발생한다(String invalidPhoneNumber) {
+        // when, then
+        assertThatThrownBy(() -> new PhoneNumber(invalidPhoneNumber))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "{index}. Phone Number : {arguments}")
+    @ValueSource(strings = {"1234567890, 가나다라, abcd, 01012345678900"})
+    void 휴대폰_번호의_형식이_잘못되었을_경우_예외를_발생한다(String invalidPhoneNumber) {
+        // when, then
+        assertThatThrownBy(() -> new PhoneNumber(invalidPhoneNumber))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "{index}. Phone Number : {arguments}")
+    @ValueSource(strings = {"010-1234-5678", "01012345678", "0101235678", "010-12345678", "010-123-5678",
+            "011-1234-5678", "019-1234-5678"})
+    void 휴대폰_번호의_형식이_올바르면_예외를_발생하지_않는다(String validPhoneNumber) {
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> new PhoneNumber(validPhoneNumber));
+    }
+
+}

--- a/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
+++ b/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
@@ -1,0 +1,45 @@
+package com.spaceclub.user.domain;
+
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+class RequiredInfoTest {
+
+    private final PhoneNumber validPhoneNumber = new PhoneNumber("010-1234-5678");
+
+    @ParameterizedTest(name = "{index}. value : {arguments}")
+    @NullSource
+    @ValueSource(strings = {"", " ", "    ", "a ", "a b", "    a   "})
+    void 닉네임이_null이거나_공백을_포함하면_예외를_발생한다(String invalidNickname) {
+        // when, then
+        assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "{index}. nickname : {arguments}")
+    @ValueSource(strings = {"1", "가", "가나다라마바사아자차카", "12345678901"})
+    void 닉네임이_2글자이상_10글자이하_범위에서_벗어나면_예외를_발생한다(String invalidNickname) {
+        // when, then
+        assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 닉네임이_2글자이상_10글자이하_범위에_있으면_예외를_발생하지_않는다() {
+        // given
+        String validNickname = "가나";
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> new RequiredInfo(validNickname, validPhoneNumber));
+    }
+
+}

--- a/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
+++ b/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
@@ -2,7 +2,6 @@ package com.spaceclub.user.domain;
 
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,26 +16,24 @@ class RequiredInfoTest {
 
     @ParameterizedTest(name = "{index}. value : {arguments}")
     @NullSource
-    @ValueSource(strings = {"", " ", "    ", "a ", "a b", "    a   "})
-    void 닉네임이_null이거나_공백을_포함하면_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
+    @ValueSource(strings = {"", " ", "    "})
+    void 닉네임이_null이거나_공백일_경우_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
         // when, then
         assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest(name = "{index}. nickname : {arguments}")
-    @ValueSource(strings = {"1", "가", "가나다라마바사아자차카", "12345678901"})
-    void 닉네임이_2글자이상_10글자이하_범위에서_벗어나면_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
+    @ValueSource(strings = {"1", "가", "가나다라마바사아자차카", "12345678901", "가   "})
+    void 양끝_공백을_제거한_닉네임이_2글자이상_10글자이하_범위에서_벗어나면_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
         // when, then
         assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test
-    void 닉네임이_2글자이상_10글자이하_범위에_있으면_필수정보_객체_생성에_생성에_성공한다() {
-        // given
-        String validNickname = "가나";
-
+    @ParameterizedTest(name = "{index}. nickname : {arguments}")
+    @ValueSource(strings = {"가나", "     가나    ", "가  나"})
+    void 양끝_공백을_제거한_닉네임이_2글자이상_10글자이하_범위에_있으면_필수정보_객체_생성에_생성에_성공한다(String validNickname) {
         // when, then
         assertThatNoException()
                 .isThrownBy(() -> new RequiredInfo(validNickname, validPhoneNumber));

--- a/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
+++ b/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
@@ -18,7 +18,7 @@ class RequiredInfoTest {
     @ParameterizedTest(name = "{index}. value : {arguments}")
     @NullSource
     @ValueSource(strings = {"", " ", "    ", "a ", "a b", "    a   "})
-    void 닉네임이_null이거나_공백을_포함하면_예외를_발생한다(String invalidNickname) {
+    void 닉네임이_null이거나_공백을_포함하면_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
         // when, then
         assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -26,14 +26,14 @@ class RequiredInfoTest {
 
     @ParameterizedTest(name = "{index}. nickname : {arguments}")
     @ValueSource(strings = {"1", "가", "가나다라마바사아자차카", "12345678901"})
-    void 닉네임이_2글자이상_10글자이하_범위에서_벗어나면_예외를_발생한다(String invalidNickname) {
+    void 닉네임이_2글자이상_10글자이하_범위에서_벗어나면_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
         // when, then
         assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void 닉네임이_2글자이상_10글자이하_범위에_있으면_예외를_발생하지_않는다() {
+    void 닉네임이_2글자이상_10글자이하_범위에_있으면_필수정보_객체_생성에_생성에_성공한다() {
         // given
         String validNickname = "가나";
 


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-146](https://mapda.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-146)
  <br>

### 🖥️ 작업 내용
- 유저는 다음과 같은 기능을 가집니다.
    - 필수 정보
        -  닉네임 (공백 포함 불가, null 불가, 2글자 이상 10자 이하)
        - 휴대폰 번호 ( 01x-(3~4글자)-(4글자) 형식 검증, - 여부는 자유) -> 저장시 - 제거
    - oauth 유저이름
    -  oauth 제공사 (확장 생각해서 분리했습니다)
    - 이메일 (x@x.(2~6글자 도메인) 으로 검증, 대소문자 구분 x) -> 추후 좀 더 고민 할 예정
    - refresh Token
<br>

### ✅ PR시 확인 사항
- [x] 테스트 코드 작성
- [x] Linear History 여부
  <br>

### 📢 리뷰어 전달 사항
- 테스트 컨벤션 관해서 좀더 이야기 해봅시다!


[SKRB-146]: https://mapda.atlassian.net/browse/SKRB-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ