### PR TITLE
[SKRB-184] refactor:  DTO 이름 변경 및  SpaceClubCustomDisplayNameGenerator 수정

### DIFF
--- a/src/main/java/com/spaceclub/global/dto/PageResponse.java
+++ b/src/main/java/com/spaceclub/global/dto/PageResponse.java
@@ -1,15 +1,15 @@
-package com.spaceclub.user.controller.dto;
+package com.spaceclub.global.dto;
 
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-public record EventPageResponse<T, E>(
+public record PageResponse<T, E>(
         List<T> data,
         PageableResponse<E> pageData
 ) {
 
-    public EventPageResponse(List<T> data, Page<E> page) {
+    public PageResponse(List<T> data, Page<E> page) {
         this(data, new PageableResponse<>(page));
     }
 

--- a/src/main/java/com/spaceclub/user/controller/UserController.java
+++ b/src/main/java/com/spaceclub/user/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.spaceclub.user.controller;
 
 import com.spaceclub.event.domain.Event;
-import com.spaceclub.user.controller.dto.EventPageResponse;
-import com.spaceclub.user.controller.dto.EventResponse;
+import com.spaceclub.global.dto.PageResponse;
+import com.spaceclub.user.controller.dto.UserEventGetResponse;
 import com.spaceclub.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,15 +22,15 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/{userId}/events")
-    public EventPageResponse<EventResponse, Event> getAllEvents(@PathVariable Long userId, Pageable pageable) {
+    public PageResponse<UserEventGetResponse, Event> getAllEvents(@PathVariable Long userId, Pageable pageable) {
         Page<Event> eventPages = userService.findAllEventPages(userId, pageable);
         System.out.println(eventPages);
-        List<EventResponse> eventResponses = eventPages.getContent()
+        List<UserEventGetResponse> eventGetRespons = eventPages.getContent()
                 .stream()
-                .map(EventResponse::from)
+                .map(UserEventGetResponse::from)
                 .toList();
 
-        return new EventPageResponse<>(eventResponses, eventPages);
+        return new PageResponse<>(eventGetRespons, eventPages);
     }
 
 }

--- a/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
+++ b/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
@@ -2,10 +2,10 @@ package com.spaceclub.user.controller.dto;
 
 import com.spaceclub.event.domain.Event;
 
-public record EventResponse(Long id, String title, String location, String host) {
+public record UserEventGetResponse(Long id, String title, String location, String host) {
 
-    public static EventResponse from(Event event) {
-        return new EventResponse(
+    public static UserEventGetResponse from(Event event) {
+        return new UserEventGetResponse(
                 event.getId(),
                 event.getEventInfo().getTitle(),
                 event.getEventInfo().getLocation(),

--- a/src/test/java/com/spaceclub/SpaceClubCustomDisplayNameGenerator.java
+++ b/src/test/java/com/spaceclub/SpaceClubCustomDisplayNameGenerator.java
@@ -4,36 +4,28 @@ import org.junit.jupiter.api.DisplayNameGenerator.Standard;
 
 import java.lang.reflect.Method;
 
-public class SpaceClubCustomDisplayNameGenerator {
+public class SpaceClubCustomDisplayNameGenerator extends Standard {
 
-    public static class ReplaceUnderscores extends Standard {
+    public static final char CHAR_CHANGE_FROM = '_';
+    public static final char CHAR_CHANGE_TO = ' ';
 
-        public static final char CHAR_CHANGE_FROM = '_';
-        public static final char CHAR_CHANGE_TO = ' ';
+    @Override
+    public String generateDisplayNameForClass(Class<?> testClass) {
+        return replaceUnderscores(super.generateDisplayNameForClass(testClass));
+    }
 
-        public ReplaceUnderscores() {
-            super();
-        }
+    @Override
+    public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+        return replaceUnderscores(super.generateDisplayNameForNestedClass(nestedClass));
+    }
 
-        @Override
-        public String generateDisplayNameForClass(Class<?> testClass) {
-            return replaceUnderscores(super.generateDisplayNameForClass(testClass));
-        }
+    @Override
+    public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+        return replaceUnderscores(testMethod.getName());
+    }
 
-        @Override
-        public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
-            return replaceUnderscores(super.generateDisplayNameForNestedClass(nestedClass));
-        }
-
-        @Override
-        public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-            return replaceUnderscores(testMethod.getName());
-        }
-
-        private static String replaceUnderscores(String name) {
-            return name.replace(CHAR_CHANGE_FROM, CHAR_CHANGE_TO);
-        }
-
+    private static String replaceUnderscores(String name) {
+        return name.replace(CHAR_CHANGE_FROM, CHAR_CHANGE_TO);
     }
 
 }

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -1,10 +1,12 @@
 package com.spaceclub.club.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.controller.dto.ClubCreateRequest;
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.club.domain.ClubNotice;
 import com.spaceclub.club.service.ClubService;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -38,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(ClubController.class)
 @AutoConfigureRestDocs
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class ClubControllerTest {
 
     @Autowired

--- a/src/test/java/com/spaceclub/club/domain/ClubTest.java
+++ b/src/test/java/com/spaceclub/club/domain/ClubTest.java
@@ -1,5 +1,7 @@
 package com.spaceclub.club.domain;
 
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -7,6 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class ClubTest {
 
     @ValueSource(strings = {"내 클럽", "연사모", "오마이클럽", "연어를 사랑하는 모임"})

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserController.class)
 @AutoConfigureRestDocs
-@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/com/spaceclub/user/domain/EmailTest.java
+++ b/src/test/java/com/spaceclub/user/domain/EmailTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class EmailTest {
 
     @ParameterizedTest(name = "{index}. email : {arguments}")

--- a/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
+++ b/src/test/java/com/spaceclub/user/domain/PhoneNumberTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class PhoneNumberTest {
 
     @ParameterizedTest(name = "{index}. Phone Number : {arguments}")

--- a/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
+++ b/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class RequiredInfoTest {
 
     private final PhoneNumber validPhoneNumber = new PhoneNumber("010-1234-5678");


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-184](https://mapda.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-184)
  <br>

### 🖥️ 작업 내용
- EventPageResponse를 PageResponse로 이름 변경해서 global > dto > 아래로 재사용할 수 있게 분리 했습니다
- SpaceClubCustomDisplayNameGenerator 수정했으니 테스트마다`@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)` 붙혀 사용하시면 될것 같아요
<br>

### ✅ PR시 확인 사항
- [x] 테스트 코드 작성
- [x] Linear History 여부
  <br>

### 📢 리뷰어 전달 사항
 == 작업내용

[SKRB-184]: https://mapda.atlassian.net/browse/SKRB-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ