### PR TITLE
[SKRB-166] feat: 중간 테이블 EventUser 및 도메인 수정

### DIFF
--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -11,10 +11,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -49,6 +53,10 @@ public class Event extends BaseTimeEntity {
     @JoinColumn(name = "club_id")
     private Club club;
 
+    @Getter
+    @OneToMany(mappedBy = "event")
+    private List<EventUser> users = new ArrayList<>();
+
     @Builder
     private Event(
             Long id,
@@ -66,11 +74,6 @@ public class Event extends BaseTimeEntity {
         this.ticketInfo = ticketInfo;
         this.formInfo = formInfo;
         this.club = club;
-    }
-
-    public String getClubHost() {
-        // TODO Club과 연관관계 설정 후 HOST (주최자) 반환하는 메서드
-        return "host";
     }
 
     public Event registerClub(Club club) {

--- a/src/main/java/com/spaceclub/event/domain/EventStatus.java
+++ b/src/main/java/com/spaceclub/event/domain/EventStatus.java
@@ -1,0 +1,10 @@
+package com.spaceclub.event.domain;
+
+public enum EventStatus {
+
+    CONFIRMED,
+    PENDING,
+    CANCELLED,
+    CANCEL_REQUESTED
+
+}

--- a/src/main/java/com/spaceclub/event/domain/EventUser.java
+++ b/src/main/java/com/spaceclub/event/domain/EventUser.java
@@ -1,0 +1,56 @@
+package com.spaceclub.event.domain;
+
+import com.spaceclub.user.domain.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class EventUser {
+
+    @Id
+    @Column(name = "event_user_id")
+    @GeneratedValue
+    private Long id;
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    private EventStatus status;
+
+    @ManyToOne(fetch = LAZY, optional = false, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY, optional = false, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Builder
+    private EventUser(Long id, EventStatus status, User user, Event event) {
+        validate(user, event);
+        this.id = id;
+        this.status = status;
+        this.user = user;
+        this.event = event;
+    }
+
+    private void validate(User user, Event event) {
+        Assert.notNull(user, "유저는 필수입니다.");
+        Assert.notNull(event, "이벤트는 필수입니다.");
+    }
+
+}

--- a/src/main/java/com/spaceclub/user/controller/UserController.java
+++ b/src/main/java/com/spaceclub/user/controller/UserController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static com.spaceclub.user.controller.dto.UserEventGetResponse.from;
+
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -24,13 +26,12 @@ public class UserController {
     @GetMapping("/{userId}/events")
     public PageResponse<UserEventGetResponse, Event> getAllEvents(@PathVariable Long userId, Pageable pageable) {
         Page<Event> eventPages = userService.findAllEventPages(userId, pageable);
-        System.out.println(eventPages);
-        List<UserEventGetResponse> eventGetRespons = eventPages.getContent()
-                .stream()
-                .map(UserEventGetResponse::from)
+
+        List<UserEventGetResponse> eventGetResponse = eventPages.getContent().stream()
+                .map(event -> from(event, userService.findEventStatus(userId, event)))
                 .toList();
 
-        return new PageResponse<>(eventGetRespons, eventPages);
+        return new PageResponse<>(eventGetResponse, eventPages);
     }
 
 }

--- a/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
+++ b/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
@@ -2,14 +2,25 @@ package com.spaceclub.user.controller.dto;
 
 import com.spaceclub.event.domain.Event;
 
-public record UserEventGetResponse(Long id, String title, String location, String host) {
+public record UserEventGetResponse(
+        Long id,
+        String title,
+        String location,
+        String clubName,
+        String poster,
+        String startDate,
+        String status
+) {
 
-    public static UserEventGetResponse from(Event event) {
+    public static UserEventGetResponse from(Event event, String eventStatus) {
         return new UserEventGetResponse(
                 event.getId(),
                 event.getEventInfo().getTitle(),
                 event.getEventInfo().getLocation(),
-                event.getClubHost()
+                event.getClub().getName(),
+                event.getEventInfo().getPoster(),
+                event.getEventInfo().getStartDate().toLocalDate().toString(),
+                eventStatus
         );
     }
 

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -63,7 +62,7 @@ public class User {
         this.provider = provider;
         this.email = email;
         this.refreshToken = refreshToken;
-        this.events = events;
+        this.events = List.copyOf(events);
     }
 
 }

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.spaceclub.user.domain;
 
+import com.spaceclub.event.domain.EventUser;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -7,8 +8,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -38,20 +43,27 @@ public class User {
     @Lob
     private String refreshToken;
 
+    @OneToMany(mappedBy = "user")
+    private List<EventUser> events;
+
     @Builder
     private User(
+            Long userId,
             String nickname,
             String phoneNumber,
             String oauthUserName,
             Provider provider,
             Email email,
-            String refreshToken
+            String refreshToken,
+            List<EventUser> events
     ) {
+        this.userid= userId;
         this.requiredInfo = new RequiredInfo(nickname, new PhoneNumber(phoneNumber));
         this.oauthUserName = oauthUserName;
         this.provider = provider;
         this.email = email;
         this.refreshToken = refreshToken;
+        this.events = events;
     }
 
 }

--- a/src/main/java/com/spaceclub/user/repository/UserRepository.java
+++ b/src/main/java/com/spaceclub/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.spaceclub.user.repository;
+
+import com.spaceclub.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/spaceclub/user/service/UserService.java
+++ b/src/main/java/com/spaceclub/user/service/UserService.java
@@ -1,15 +1,28 @@
 package com.spaceclub.user.service;
 
 import com.spaceclub.event.domain.Event;
+import com.spaceclub.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
+    private final EventRepository eventRepository;
+
     public Page<Event> findAllEventPages(Long userId, Pageable pageable) {
+//        return eventRepository.findAllByUserId(userId, pageable);
+        return null;
+    }
+
+    public String findEventStatus(Long userId, Event event) {
+//        return eventRepository.findEventStatusByUserId(userId, event);
         return null;
     }
 
 }
+
+

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -1,9 +1,7 @@
 package com.spaceclub.user.controller;
 
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
-import com.spaceclub.event.domain.Category;
 import com.spaceclub.event.domain.Event;
-import com.spaceclub.event.domain.EventInfo;
 import com.spaceclub.user.service.UserService;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
@@ -18,10 +16,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.spaceclub.event.EventTestFixture.event1;
+import static com.spaceclub.event.EventTestFixture.event2;
+import static com.spaceclub.event.EventTestFixture.event3;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -55,46 +56,12 @@ class UserControllerTest {
     void 유저의_모든_이벤트_조회에_성공한다() throws Exception {
         // given
         final Long userId = 1L;
-        List<Event> events = List.of(
-                Event.builder()
-                        .id(1L)
-                        .category(Category.SHOW)
-                        .eventInfo(
-                                EventInfo.builder()
-                                        .title("title1")
-                                        .content("content1")
-                                        .startDate(LocalDateTime.of(2023, 9, 20, 15, 30, 30))
-                                        .location("location1")
-                                        .capacity(10).build()
-                        )
-                        .build(),
-                Event.builder()
-                        .id(2L)
-                        .category(Category.SHOW)
-                        .eventInfo(
-                                EventInfo.builder()
-                                        .title("title2")
-                                        .content("content2")
-                                        .startDate(LocalDateTime.of(2023, 9, 20, 15, 30, 30))
-                                        .location("location2")
-                                        .capacity(50).build()
-                        )
-                        .build(),
-                Event.builder()
-                        .id(3L)
-                        .category(Category.SHOW)
-                        .eventInfo(
-                                EventInfo.builder()
-                                        .title("title3")
-                                        .content("content3")
-                                        .startDate(LocalDateTime.of(2023, 9, 20, 15, 30, 30))
-                                        .location("location3").capacity(100).build()
-                        )
-                        .build()
-        );
+        List<Event> events = List.of(event1(), event2(), event3());
         PageRequest pageRequest = PageRequest.of(1, 10, Sort.by(DESC, "startDate"));
         Page<Event> eventPages = new PageImpl<>(events);
+
         given(userService.findAllEventPages(userId, pageRequest)).willReturn(eventPages);
+//        given(userService.findEventStatus(eq(userId), any())).willReturn("CONFIRMED");
 
         // when, then
         mvc.perform(get("/api/v1/users/{userId}/events", userId)
@@ -124,7 +91,10 @@ class UserControllerTest {
                                         fieldWithPath("data[].id").type(NUMBER).description("이벤트 아이디"),
                                         fieldWithPath("data[].title").type(STRING).description("이벤트 제목"),
                                         fieldWithPath("data[].location").type(STRING).description("이벤트 위치"),
-                                        fieldWithPath("data[].host").type(STRING).description("이벤트 주최자"),
+                                        fieldWithPath("data[].clubName").type(STRING).description("이벤트 주최자"),
+                                        fieldWithPath("data[].poster").type(STRING).description("포스터 URL"),
+                                        fieldWithPath("data[].startDate").type(STRING).description("이벤트 시작일"),
+                                        fieldWithPath("data[].status").type(STRING).description("이벤트 상태"),
                                         fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),
                                         fieldWithPath("pageData.first").type(BOOLEAN).description("첫 페이지 여부"),
                                         fieldWithPath("pageData.last").type(BOOLEAN).description("마지막 페이지 여부"),

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -61,7 +61,7 @@ class UserControllerTest {
         Page<Event> eventPages = new PageImpl<>(events);
 
         given(userService.findAllEventPages(userId, pageRequest)).willReturn(eventPages);
-//        given(userService.findEventStatus(eq(userId), any())).willReturn("CONFIRMED");
+        given(userService.findEventStatus(eq(userId), any())).willReturn("CONFIRMED");
 
         // when, then
         mvc.perform(get("/api/v1/users/{userId}/events", userId)


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-166](https://mapda.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-166)
  <br>

### 🖥️ 작업 내용
- 도메인 수정 
- event - user 사이 중간테이블 설정
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
  <br>

### 📢 리뷰어 전달 사항
- 생성자에 id를 포함하지 않으면 테스트가 힘듭니다 => id값을 넣어야합니다.

[SKRB-166]: https://mapda.atlassian.net/browse/SKRB-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ