### PR TITLE
[SKRB-241] chore: Entity, RequestBody, ResponseBody의 컬럼명 변경

### DIFF
--- a/src/main/java/com/spaceclub/club/controller/ClubController.java
+++ b/src/main/java/com/spaceclub/club/controller/ClubController.java
@@ -44,8 +44,8 @@ public class ClubController {
 
     @PostMapping(value = "/clubs", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> createClub(@RequestPart(value = "request") ClubCreateRequest request,
-                                             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail) throws IOException {
-        if (thumbnail == null) {
+                                             @RequestPart(value = "logoImage", required = false) MultipartFile logoImage) throws IOException {
+        if (logoImage == null) {
             Club newClub = request.toEntity();
             Club createdClub = service.createClub(newClub);
             Long id = createdClub.getId();
@@ -53,8 +53,8 @@ public class ClubController {
             return ResponseEntity.created(URI.create("/api/v1/clubs/" + id)).build();
         }
 
-        String thumbnailUrl = uploader.uploadClubThumbnail(thumbnail);
-        Club newClub = request.toEntity(thumbnailUrl);
+        String logoImageUrl = uploader.uploadClubLogoImage(logoImage);
+        Club newClub = request.toEntity(logoImageUrl);
         Club createdClub = service.createClub(newClub);
         Long id = createdClub.getId();
 

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubCreateRequest.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubCreateRequest.java
@@ -1,6 +1,5 @@
 package com.spaceclub.club.controller.dto;
 
-import com.spaceclub.club.InvitationCodeGenerator;
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.club.domain.Invitation;
 

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubCreateRequest.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubCreateRequest.java
@@ -21,13 +21,13 @@ public record ClubCreateRequest(
                 .build();
     }
 
-    public Club toEntity(String thumbnailUrl) {
+    public Club toEntity(String logoImageUrl) {
         return Club.builder()
                 .name(name)
                 .info(info)
                 .owner(owner)
                 .invitation(InvitationCreateRequest.toEntity())
-                .thumbnailUrl(thumbnailUrl)
+                .logoImageUrl(logoImageUrl)
                 .build();
     }
 

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubEventGetResponse.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubEventGetResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 public record ClubEventGetResponse(
         Long id,
         String title,
-        String poster,
+        String posterImageUrl,
         LocalDate startDate,
         LocalTime startTime,
         String location,
@@ -25,7 +25,7 @@ public record ClubEventGetResponse(
         return new ClubEventGetResponse(
                 event.getId(),
                 event.getTitle(),
-                event.getPoster(),
+                event.getPosterImageUrl(),
                 event.getStartDate(),
                 event.getStartTime(),
                 event.getLocation(),

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubEventGetResponse.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubEventGetResponse.java
@@ -17,7 +17,7 @@ public record ClubEventGetResponse(
         LocalTime startTime,
         String location,
         String clubName,
-        String clubImage,
+        String clubLogoImageUrl,
         String openStatus
 ) {
 
@@ -30,7 +30,7 @@ public record ClubEventGetResponse(
                 event.getStartTime(),
                 event.getLocation(),
                 event.getClubName(),
-                event.getClubImage(),
+                event.getClubLogoImageUrl(),
                 event.getCategory().equals(Category.CLUB) ? "CLUB" : "ALL"
         );
     }

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubGetResponse.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubGetResponse.java
@@ -33,7 +33,7 @@ public record ClubGetResponse(
                 .name(club.getName())
                 .info(club.getInfo())
                 .memberCount(memberCount)
-                .image(club.getThumbnailUrl())
+                .image(club.getLogoImageUrl())
                 .notices(club.getNotices().stream()
                         .map(ClubNotice::getNotice)
                         .toList())

--- a/src/main/java/com/spaceclub/club/controller/dto/MemberGetResponse.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/MemberGetResponse.java
@@ -7,15 +7,15 @@ import lombok.Builder;
 public record MemberGetResponse(
         Long id,
         String name,
-        String image,
+        String profileImageUrl,
         ClubUserRole role
 ) {
 
     @Builder
-    public MemberGetResponse(Long id, String name, String image, ClubUserRole role) {
+    public MemberGetResponse(Long id, String name, String profileImageUrl, ClubUserRole role) {
         this.id = id;
         this.name = name;
-        this.image = image;
+        this.profileImageUrl = profileImageUrl;
         this.role = role;
     }
 
@@ -24,7 +24,7 @@ public record MemberGetResponse(
         return MemberGetResponse.builder()
                 .id(clubUser.getUserId())
                 .name(clubUser.getName())
-                .image(clubUser.getImage())
+                .profileImageUrl(clubUser.getProfileImageUrl())
                 .role(clubUser.getRole())
                 .build();
     }

--- a/src/main/java/com/spaceclub/club/domain/Club.java
+++ b/src/main/java/com/spaceclub/club/domain/Club.java
@@ -39,7 +39,7 @@ public class Club extends BaseTimeEntity {
 
     @Lob
     @Getter
-    private String thumbnailUrl;
+    private String logoImageUrl;
 
     @Lob
     @Getter
@@ -64,7 +64,7 @@ public class Club extends BaseTimeEntity {
     }
 
     @Builder
-    public Club(Long id, String name, String thumbnailUrl, String info, String owner, Invitation invitation, List<ClubNotice> notices) {
+    public Club(Long id, String name, String logoImageUrl, String info, String owner, Invitation invitation, List<ClubNotice> notices) {
         Assert.notNull(name, "이름에 null 값이 올 수 없습니다");
         Assert.hasText(name, "이름이 빈 값일 수 없습니다");
         Assert.isTrue(validateNameLength(name), "이름의 길이는 12글자를 넘을 수 없습니다");
@@ -72,7 +72,7 @@ public class Club extends BaseTimeEntity {
 
         this.id = id;
         this.name = name;
-        this.thumbnailUrl = thumbnailUrl;
+        this.logoImageUrl = logoImageUrl;
         this.info = info;
         this.owner = owner;
         this.invitation = invitation;

--- a/src/main/java/com/spaceclub/club/domain/ClubUser.java
+++ b/src/main/java/com/spaceclub/club/domain/ClubUser.java
@@ -67,8 +67,8 @@ public class ClubUser extends BaseTimeEntity {
         return user.getName();
     }
 
-    public String getImage() {
-        return user.getImage();
+    public String getProfileImageUrl() {
+        return user.getProfileImageUrl();
     }
 
 }

--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -36,9 +36,9 @@ public class EventController {
     private final S3ImageUploader uploader;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> create(@RequestPart EventCreateRequest request, @RequestPart MultipartFile poster) throws IOException {
-        String fileName = uploader.uploadImage(poster);
-        Long eventId = eventService.create(request.toEntity(fileName), request.clubId());
+    public ResponseEntity<String> create(@RequestPart EventCreateRequest request, @RequestPart MultipartFile posterImage) throws IOException {
+        String posterImageUrl = uploader.uploadImage(posterImage);
+        Long eventId = eventService.create(request.toEntity(posterImageUrl), request.clubId());
 
         return ResponseEntity.created(URI.create("/api/v1/events/" + eventId)).build();
     }

--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -37,7 +37,7 @@ public class EventController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> create(@RequestPart EventCreateRequest request, @RequestPart MultipartFile posterImage) throws IOException {
-        String posterImageUrl = uploader.uploadImage(posterImage);
+        String posterImageUrl = uploader.uploadPosterImage(posterImage);
         Long eventId = eventService.create(request.toEntity(posterImageUrl), request.clubId());
 
         return ResponseEntity.created(URI.create("/api/v1/events/" + eventId)).build();

--- a/src/main/java/com/spaceclub/event/controller/dto/EventCreateRequest.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventCreateRequest.java
@@ -19,10 +19,10 @@ public record EventCreateRequest(
         FormInfoRequest formInfo
 ) {
 
-    public Event toEntity(String posterUrl) {
+    public Event toEntity(String posterImageUrl) {
         return Event.builder()
                 .category(category)
-                .eventInfo(eventInfo.toEntity(posterUrl))
+                .eventInfo(eventInfo.toEntity(posterImageUrl))
                 .ticketInfo(ticketInfo.toEntity())
                 .bankInfo(bankInfo.toEntity())
                 .formInfo(formInfo.toEntity())
@@ -82,14 +82,14 @@ public record EventCreateRequest(
             int capacity
     ) {
 
-        public EventInfo toEntity(String posterUrl) {
+        public EventInfo toEntity(String posterImageUrl) {
             return EventInfo.builder()
                     .title(title)
                     .content(content)
                     .startDate(startDate.atTime(startTime))
                     .location(location)
                     .capacity(capacity)
-                    .poster(posterUrl)
+                    .posterImageUrl(posterImageUrl)
                     .build();
         }
 

--- a/src/main/java/com/spaceclub/event/controller/dto/EventDetailGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventDetailGetResponse.java
@@ -15,7 +15,7 @@ public record EventDetailGetResponse(
         LocalTime startTime,
         String location,
         String clubName,
-        String clubImage,
+        String clubLogoImageUrl,
         LocalDateTime formOpenDateTime,
         LocalDateTime formCloseDateTime
 ) {
@@ -33,7 +33,7 @@ public record EventDetailGetResponse(
                 .startTime(event.getStartTime())
                 .location(event.getLocation())
                 .clubName(event.getClubName())
-                .clubImage(event.getClubImage())
+                .clubLogoImageUrl(event.getClubLogoImageUrl())
                 .formOpenDateTime(event.getFormOpenDate())
                 .formCloseDateTime(event.getFormCloseDate())
                 .build();

--- a/src/main/java/com/spaceclub/event/controller/dto/EventDetailGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventDetailGetResponse.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 public record EventDetailGetResponse(
         Long id,
         String title,
-        String poster,
+        String posterImageUrl,
         LocalDate startDate,
         LocalTime startTime,
         String location,
@@ -28,7 +28,7 @@ public record EventDetailGetResponse(
         return EventDetailGetResponse.builder()
                 .id(event.getId())
                 .title(event.getTitle())
-                .poster(event.getPoster())
+                .posterImageUrl(event.getPosterImageUrl())
                 .startDate(event.getStartDate())
                 .startTime(event.getStartTime())
                 .location(event.getLocation())

--- a/src/main/java/com/spaceclub/event/controller/dto/EventGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventGetResponse.java
@@ -13,7 +13,7 @@ public record EventGetResponse(
         LocalTime startTime,
         String location,
         String clubName,
-        String clubImage
+        String clubLogoImageUrl
 ) {
 
     public static EventGetResponse from(Event event) {
@@ -25,7 +25,7 @@ public record EventGetResponse(
                 event.getEventInfo().getStartDate().toLocalTime(),
                 event.getEventInfo().getLocation(),
                 event.getClub().getName(),
-                event.getClub().getThumbnailUrl()
+                event.getClub().getLogoImageUrl()
         );
     }
 

--- a/src/main/java/com/spaceclub/event/controller/dto/EventGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventGetResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalTime;
 public record EventGetResponse(
         Long id,
         String title,
-        String poster,
+        String posterImageUrl,
         LocalDate startDate,
         LocalTime startTime,
         String location,
@@ -20,7 +20,7 @@ public record EventGetResponse(
         return new EventGetResponse(
                 event.getId(),
                 event.getEventInfo().getTitle(),
-                event.getEventInfo().getPoster(),
+                event.getEventInfo().getPosterImageUrl(),
                 event.getEventInfo().getStartDate().toLocalDate(),
                 event.getEventInfo().getStartDate().toLocalTime(),
                 event.getEventInfo().getLocation(),

--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -122,8 +122,8 @@ public class Event extends BaseTimeEntity {
         return club.getName();
     }
 
-    public String getClubImage() {
-        return club.getThumbnailUrl();
+    public String getClubLogoImageUrl() {
+        return club.getLogoImageUrl();
     }
 
     public LocalDateTime getFormOpenDate() {

--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -98,8 +98,8 @@ public class Event extends BaseTimeEntity {
         return eventInfo.getTitle();
     }
 
-    public String getPoster() {
-        return eventInfo.getPoster();
+    public String getPosterImageUrl() {
+        return eventInfo.getPosterImageUrl();
     }
 
     public LocalDate getStartDate() {

--- a/src/main/java/com/spaceclub/event/domain/EventInfo.java
+++ b/src/main/java/com/spaceclub/event/domain/EventInfo.java
@@ -29,16 +29,16 @@ public class EventInfo {
     private int capacity;
 
     @Getter
-    private String poster;
+    private String posterImageUrl;
 
     @Builder
-    private EventInfo(String title, String content, LocalDateTime startDate, String location, int capacity, String poster) {
+    private EventInfo(String title, String content, LocalDateTime startDate, String location, int capacity, String posterImageUrl) {
         this.title = title;
         this.content = content;
         this.startDate = startDate;
         this.location = location;
         this.capacity = capacity;
-        this.poster = poster;
+        this.posterImageUrl = posterImageUrl;
     }
 
 }

--- a/src/main/java/com/spaceclub/event/repository/EventRepository.java
+++ b/src/main/java/com/spaceclub/event/repository/EventRepository.java
@@ -1,6 +1,5 @@
 package com.spaceclub.event.repository;
 
-import com.spaceclub.event.domain.Category;
 import com.spaceclub.event.domain.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/spaceclub/global/BaseTimeEntity.java
+++ b/src/main/java/com/spaceclub/global/BaseTimeEntity.java
@@ -2,7 +2,6 @@ package com.spaceclub.global;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/spaceclub/global/S3ImageUploader.java
+++ b/src/main/java/com/spaceclub/global/S3ImageUploader.java
@@ -29,20 +29,20 @@ public class S3ImageUploader {
     @Value("${s3.bucket.club-name}")
     private String clubS3BucketName;
 
-    public String uploadImage(MultipartFile poster) throws IOException {
-        String newFileName = createFileName(poster.getOriginalFilename());
+    public String uploadImage(MultipartFile posterImage) throws IOException {
+        String newFileName = createFileName(posterImage.getOriginalFilename());
 
         ObjectMetadata objectMetaData = new ObjectMetadata();
 
-        objectMetaData.setContentType(poster.getContentType());
-        objectMetaData.setContentLength(poster.getSize());
+        objectMetaData.setContentType(posterImage.getContentType());
+        objectMetaData.setContentLength(posterImage.getSize());
 
         amazonS3Client.putObject(
-                new PutObjectRequest(s3BucketName, newFileName, poster.getInputStream(), objectMetaData)
+                new PutObjectRequest(s3BucketName, newFileName, posterImage.getInputStream(), objectMetaData)
                         .withCannedAcl(CannedAccessControlList.PublicRead)
         );
 
-        return getSavedFileName(poster);
+        return getSavedFileName(posterImage);
     }
 
     public String uploadClubLogoImage(MultipartFile logoImage) throws IOException {
@@ -61,8 +61,8 @@ public class S3ImageUploader {
         return getSavedFileName(logoImage);
     }
 
-    private String getSavedFileName(MultipartFile poster) {
-        String fullImageUrl = amazonS3Client.getUrl(s3BucketName, poster.getOriginalFilename()).toString();
+    private String getSavedFileName(MultipartFile posterImage) {
+        String fullImageUrl = amazonS3Client.getUrl(s3BucketName, posterImage.getOriginalFilename()).toString();
         String[] parts = fullImageUrl.split(SLASH);
 
         return parts[parts.length - 1];

--- a/src/main/java/com/spaceclub/global/S3ImageUploader.java
+++ b/src/main/java/com/spaceclub/global/S3ImageUploader.java
@@ -29,7 +29,7 @@ public class S3ImageUploader {
     @Value("${s3.bucket.club-name}")
     private String clubS3BucketName;
 
-    public String uploadImage(MultipartFile posterImage) throws IOException {
+    public String uploadPosterImage(MultipartFile posterImage) throws IOException {
         String newFileName = createFileName(posterImage.getOriginalFilename());
 
         ObjectMetadata objectMetaData = new ObjectMetadata();

--- a/src/main/java/com/spaceclub/global/S3ImageUploader.java
+++ b/src/main/java/com/spaceclub/global/S3ImageUploader.java
@@ -45,20 +45,20 @@ public class S3ImageUploader {
         return getSavedFileName(poster);
     }
 
-    public String uploadClubThumbnail(MultipartFile thumbnail) throws IOException {
-        String newFileName = createFileName(thumbnail.getOriginalFilename());
+    public String uploadClubLogoImage(MultipartFile logoImage) throws IOException {
+        String newFileName = createFileName(logoImage.getOriginalFilename());
 
         ObjectMetadata objectMetaData = new ObjectMetadata();
 
-        objectMetaData.setContentType(thumbnail.getContentType());
-        objectMetaData.setContentLength(thumbnail.getSize());
+        objectMetaData.setContentType(logoImage.getContentType());
+        objectMetaData.setContentLength(logoImage.getSize());
 
         amazonS3Client.putObject(
-                new PutObjectRequest(clubS3BucketName, newFileName, thumbnail.getInputStream(), objectMetaData)
+                new PutObjectRequest(clubS3BucketName, newFileName, logoImage.getInputStream(), objectMetaData)
                         .withCannedAcl(CannedAccessControlList.PublicRead)
         );
 
-        return getSavedFileName(thumbnail);
+        return getSavedFileName(logoImage);
     }
 
     private String getSavedFileName(MultipartFile poster) {

--- a/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
+++ b/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
@@ -7,7 +7,7 @@ public record UserEventGetResponse(
         String title,
         String location,
         String clubName,
-        String poster,
+        String posterImageUrl,
         String startDate,
         String status
 ) {
@@ -18,7 +18,7 @@ public record UserEventGetResponse(
                 event.getEventInfo().getTitle(),
                 event.getEventInfo().getLocation(),
                 event.getClub().getName(),
-                event.getEventInfo().getPoster(),
+                event.getEventInfo().getPosterImageUrl(),
                 event.getEventInfo().getStartDate().toLocalDate().toString(),
                 eventStatus
         );

--- a/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
+++ b/src/main/java/com/spaceclub/user/domain/RequiredInfo.java
@@ -15,29 +15,29 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class RequiredInfo {
 
-    private static final int MIN_NICKNAME_LENGTH = 2;
-    private static final int MAX_NICKNAME_LENGTH = 10;
+    private static final int MIN_NAME_LENGTH = 2;
+    private static final int MAX_NAME_LENGTH = 10;
 
     @Getter
     @Column(nullable = false, columnDefinition = "varchar(10) default UNKNOWN")
-    private String nickname;
+    private String name;
 
     @Embedded
     private PhoneNumber phoneNumber;
 
-    public RequiredInfo(String nickname, PhoneNumber phoneNumber) {
-        validate(nickname);
-        this.nickname = nickname.trim();
+    public RequiredInfo(String name, PhoneNumber phoneNumber) {
+        validate(name);
+        this.name = name.trim();
         this.phoneNumber = phoneNumber;
     }
 
-    private void validate(String nickname) {
-        Assert.hasText(nickname, "닉네임을 입력해 주세요.");
-        Assert.isTrue(isValidRange(nickname.trim()), "닉네임은 2자 이상 10자 이하로 입력해 주세요.");
+    private void validate(String name) {
+        Assert.hasText(name, "이름을 입력해 주세요.");
+        Assert.isTrue(isValidRange(name.trim()), "이름은 2자 이상 10자 이하로 입력해 주세요.");
     }
 
-    private boolean isValidRange(String nickname) {
-        return nickname.length() >= MIN_NICKNAME_LENGTH && nickname.length() <= MAX_NICKNAME_LENGTH;
+    private boolean isValidRange(String name) {
+        return name.length() >= MIN_NAME_LENGTH && name.length() <= MAX_NAME_LENGTH;
     }
 
     public String getPhoneNumber() {

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -47,7 +47,7 @@ public class User {
 
     @Lob
     @Getter
-    private String image;
+    private String profileImageUrl;
 
     @OneToMany(mappedBy = "user")
     private List<EventUser> events = new ArrayList<>();
@@ -61,7 +61,7 @@ public class User {
             Provider provider,
             String email,
             String refreshToken,
-            String image
+            String profileImageUrl
     ) {
         this.id = id;
         this.requiredInfo = new RequiredInfo(nickname, new PhoneNumber(phoneNumber));
@@ -69,7 +69,7 @@ public class User {
         this.provider = provider;
         this.email = new Email(email);
         this.refreshToken = refreshToken;
-        this.image = image;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public String getName() {

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -55,7 +55,7 @@ public class User {
     @Builder
     private User(
             Long id,
-            String nickname,
+            String name,
             String phoneNumber,
             String oauthId,
             Provider provider,
@@ -64,7 +64,7 @@ public class User {
             String profileImageUrl
     ) {
         this.id = id;
-        this.requiredInfo = new RequiredInfo(nickname, new PhoneNumber(phoneNumber));
+        this.requiredInfo = new RequiredInfo(name, new PhoneNumber(phoneNumber));
         this.oauthUserName = generateOauthUsername(oauthId, provider);
         this.provider = provider;
         this.email = new Email(email);
@@ -73,7 +73,7 @@ public class User {
     }
 
     public String getName() {
-        return requiredInfo.getNickname();
+        return requiredInfo.getName();
     }
 
     private String generateOauthUsername(String oauthId, Provider provider) {

--- a/src/test/java/com/spaceclub/club/ClubTestFixture.java
+++ b/src/test/java/com/spaceclub/club/ClubTestFixture.java
@@ -8,7 +8,7 @@ public class ClubTestFixture {
         return Club.builder()
                 .id(1L)
                 .name("클럽 명")
-                .thumbnailUrl("클럽 이미지 URL")
+                .logoImageUrl("클럽 이미지 URL")
                 .info("클럽 정보")
                 .owner("클럽 주인")
                 .build();
@@ -18,7 +18,7 @@ public class ClubTestFixture {
         return Club.builder()
                 .id(2L)
                 .name("클럽 명")
-                .thumbnailUrl("클럽 이미지 URL")
+                .logoImageUrl("클럽 이미지 URL")
                 .info("클럽 정보")
                 .owner("클럽 주인")
                 .build();

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -293,7 +293,7 @@ class ClubControllerTest {
                                 fieldWithPath("[]").type(ARRAY).description("멤버 리스트"),
                                 fieldWithPath("[].id").type(NUMBER).description("멤버 아이디"),
                                 fieldWithPath("[].name").type(STRING).description("멤버 이름"),
-                                fieldWithPath("[].image").type(STRING).description("멤버 이미지"),
+                                fieldWithPath("[].profileImageUrl").type(STRING).description("멤버 이미지 Url"),
                                 fieldWithPath("[].role").type(STRING).description("멤버 권한")
 
                         )

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -101,7 +101,7 @@ class ClubControllerTest {
                         .name("연사모")
                         .info("연어를 사랑하는 모임")
                         .owner("연어대장")
-                        .thumbnailUrl("연어.jpg")
+                        .logoImageUrl("연어.jpg")
                         .build());
 
         ClubCreateRequest clubCreateRequest = new ClubCreateRequest(
@@ -110,9 +110,9 @@ class ClubControllerTest {
                 "연어대장"
         );
 
-        MockMultipartFile thumbnail = new MockMultipartFile(
-                "thumbnail",
-                "thumbnail.jpg",
+        MockMultipartFile logoImage = new MockMultipartFile(
+                "logoImage",
+                "logoImage.jpg",
                 MediaType.IMAGE_JPEG_VALUE,
                 "<<jpeg data>>".getBytes()
         );
@@ -128,7 +128,7 @@ class ClubControllerTest {
         // when
         ResultActions result = this.mockMvc.perform(multipart("/api/v1/clubs")
                 .file(request)
-                .file(thumbnail)
+                .file(logoImage)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                 .accept(MediaType.APPLICATION_JSON)
                 .characterEncoding(StandardCharsets.UTF_8)
@@ -144,7 +144,7 @@ class ClubControllerTest {
                         preprocessResponse(prettyPrint()),
                         requestParts(
                                 partWithName("request").description("클럽 생성 요청 DTO"),
-                                partWithName("thumbnail").description("클럽 썸네일 이미지")
+                                partWithName("logoImage").description("클럽 썸네일 이미지")
                         ),
                         requestPartFields(
                                 "request",
@@ -166,7 +166,7 @@ class ClubControllerTest {
                 Club.builder()
                         .name("연사모")
                         .info("이곳은 연사모입니다")
-                        .thumbnailUrl("연어.png")
+                        .logoImageUrl("연어.png")
                         .owner("연어대장")
                         .notices(List.of(new ClubNotice("연사모의 공지사항1")))
                         .build()
@@ -259,7 +259,7 @@ class ClubControllerTest {
                                 fieldWithPath("data[].startTime").type(STRING).description("행사 시간"),
                                 fieldWithPath("data[].location").type(STRING).description("행사 위치"),
                                 fieldWithPath("data[].clubName").type(STRING).description("클럽 명"),
-                                fieldWithPath("data[].clubImage").type(STRING).description("클럽 이미지"),
+                                fieldWithPath("data[].clubLogoImageUrl").type(STRING).description("클럽 로고 이미지 Url"),
                                 fieldWithPath("data[].openStatus").type(STRING).description("행사 공개 상태"),
                                 fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),
                                 fieldWithPath("pageData.first").type(BOOLEAN).description("첫 페이지 여부"),

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -253,7 +253,7 @@ class ClubControllerTest {
                                 fieldWithPath("data").type(ARRAY).description("페이지 내 행사 정보"),
                                 fieldWithPath("data[].id").type(NUMBER).description("행사 아이디"),
                                 fieldWithPath("data[].title").type(STRING).description("행사 제목"),
-                                fieldWithPath("data[].poster").type(STRING).description("포스터 URL"),
+                                fieldWithPath("data[].posterImageUrl").type(STRING).description("포스터 URL"),
                                 fieldWithPath("data[].location").type(STRING).description("행사 위치"),
                                 fieldWithPath("data[].startDate").type(STRING).description("행사 날짜"),
                                 fieldWithPath("data[].startTime").type(STRING).description("행사 시간"),

--- a/src/test/java/com/spaceclub/club/service/ClubServiceTest.java
+++ b/src/test/java/com/spaceclub/club/service/ClubServiceTest.java
@@ -53,7 +53,7 @@ class ClubServiceTest {
                 .name("연사모")
                 .info("연어를 사랑하는 모임")
                 .owner("연어대장")
-                .thumbnailUrl("연어.jpg")
+                .logoImageUrl("연어.jpg")
                 .notices(List.of(new ClubNotice("연어 공지사항 1: 연어는 맛있어요")))
                 .build();
     }

--- a/src/test/java/com/spaceclub/event/EventTestFixture.java
+++ b/src/test/java/com/spaceclub/event/EventTestFixture.java
@@ -20,7 +20,7 @@ public class EventTestFixture {
                 .startDate(LocalDateTime.of(2023, 9, 21, 12, 30, 30))
                 .location("위치")
                 .capacity(100)
-                .poster("www.aaa.com")
+                .posterImageUrl("www.aaa.com")
                 .build();
     }
 

--- a/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
@@ -119,7 +119,7 @@ class EventControllerTest {
         );
 
         final String posterImageUrl = "image.jpeg";
-        given(uploader.uploadImage(any(MultipartFile.class))).willReturn(posterImageUrl);
+        given(uploader.uploadPosterImage(any(MultipartFile.class))).willReturn(posterImageUrl);
         given(eventService.create(any(Event.class), any(Long.class))).willReturn(1L);
 
         // when

--- a/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
@@ -105,8 +105,8 @@ class EventControllerTest {
     @WithMockUser
     public void 행사_생성에_성공한다() throws Exception {
         // given
-        MockMultipartFile poster = new MockMultipartFile(
-                "poster",
+        MockMultipartFile posterImage = new MockMultipartFile(
+                "posterImage",
                 "image.png",
                 MediaType.IMAGE_JPEG_VALUE,
                 "<<jpeg data>>".getBytes());
@@ -118,13 +118,13 @@ class EventControllerTest {
                 mapper.writeValueAsBytes(eventCreateRequest)
         );
 
-        final String posterUrl = "image.jpeg";
-        given(uploader.uploadImage(any(MultipartFile.class))).willReturn(posterUrl);
+        final String posterImageUrl = "image.jpeg";
+        given(uploader.uploadImage(any(MultipartFile.class))).willReturn(posterImageUrl);
         given(eventService.create(any(Event.class), any(Long.class))).willReturn(1L);
 
         // when
         ResultActions actions = mvc.perform(multipart("/api/v1/events")
-                .file(poster)
+                .file(posterImage)
                 .file(request)
                 .with(csrf())
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -140,7 +140,7 @@ class EventControllerTest {
                         requestParts(
                                 partWithName("request").description("행사 생성 관련 정보")
                                         .attributes(key("content-type").value(MediaType.APPLICATION_JSON_VALUE)),
-                                partWithName("poster").description("포스터 사진")
+                                partWithName("posterImage").description("포스터 사진")
                                         .attributes(key("content-type").value(MediaType.IMAGE_JPEG_VALUE))
                         ),
                         requestPartFields("request",
@@ -205,7 +205,7 @@ class EventControllerTest {
                                 fieldWithPath("data").type(ARRAY).description("페이지 내 행사 정보"),
                                 fieldWithPath("data[].id").type(NUMBER).description("행사 아이디"),
                                 fieldWithPath("data[].title").type(STRING).description("행사 제목"),
-                                fieldWithPath("data[].poster").type(STRING).description("포스터 URL"),
+                                fieldWithPath("data[].posterImageUrl").type(STRING).description("포스터 URL"),
                                 fieldWithPath("data[].location").type(STRING).description("행사 위치"),
                                 fieldWithPath("data[].startDate").type(STRING).description("행사 날짜"),
                                 fieldWithPath("data[].startTime").type(STRING).description("행사 시간"),
@@ -273,7 +273,7 @@ class EventControllerTest {
                         responseFields(
                                 fieldWithPath("id").type(NUMBER).description("행사 ID"),
                                 fieldWithPath("title").type(STRING).description("행사 제목"),
-                                fieldWithPath("poster").type(STRING).description("행사 포스터 URL"),
+                                fieldWithPath("posterImageUrl").type(STRING).description("행사 포스터 URL"),
                                 fieldWithPath("startDate").type(STRING).description("행사 시작 날짜"),
                                 fieldWithPath("startTime").type(STRING).description("행사 시작 시각"),
                                 fieldWithPath("location").type(STRING).description("행사 위치"),

--- a/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
@@ -211,7 +211,7 @@ class EventControllerTest {
                                 fieldWithPath("data[].startTime").type(STRING).description("행사 시간"),
                                 fieldWithPath("data[].location").type(STRING).description("행사 위치"),
                                 fieldWithPath("data[].clubName").type(STRING).description("클럽 명"),
-                                fieldWithPath("data[].clubImage").type(STRING).description("클럽 이미지"),
+                                fieldWithPath("data[].clubLogoImageUrl").type(STRING).description("클럽 로그 이미지 Url"),
                                 fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),
                                 fieldWithPath("pageData.first").type(BOOLEAN).description("첫 페이지 여부"),
                                 fieldWithPath("pageData.last").type(BOOLEAN).description("마지막 페이지 여부"),
@@ -278,7 +278,7 @@ class EventControllerTest {
                                 fieldWithPath("startTime").type(STRING).description("행사 시작 시각"),
                                 fieldWithPath("location").type(STRING).description("행사 위치"),
                                 fieldWithPath("clubName").type(STRING).description("행사 주최 클럽 이름"),
-                                fieldWithPath("clubImage").type(STRING).description("행사 주최 클럽 이미지"),
+                                fieldWithPath("clubLogoImageUrl").type(STRING).description("행사 주최 클럽 로고 이미지 Url"),
                                 fieldWithPath("formOpenDateTime").type(STRING).description("행사 참여 신청 시작 날짜와 시간"),
                                 fieldWithPath("formCloseDateTime").type(STRING).description("행사 참여 신청 종료 날짜와 시간")
                         )));

--- a/src/test/java/com/spaceclub/event/repository/EventUserRepositoryTest.java
+++ b/src/test/java/com/spaceclub/event/repository/EventUserRepositoryTest.java
@@ -48,7 +48,7 @@ class EventUserRepositoryTest {
         Club club = Club.builder()
                 .id(1L)
                 .name("클럽 명")
-                .thumbnailUrl("클럽 썸네일 이미지 URL")
+                .logoImageUrl("클럽 썸네일 이미지 URL")
                 .info("클럽 정보")
                 .owner("클럽 주인")
                 .build();

--- a/src/test/java/com/spaceclub/event/repository/EventUserRepositoryTest.java
+++ b/src/test/java/com/spaceclub/event/repository/EventUserRepositoryTest.java
@@ -56,7 +56,7 @@ class EventUserRepositoryTest {
 
         User user = User.builder()
                 .id(1L)
-                .nickname("nickname1")
+                .name("name")
                 .phoneNumber("010-1234-5678")
                 .oauthId("1234")
                 .provider(Provider.KAKAO)

--- a/src/test/java/com/spaceclub/user/UserTestFixture.java
+++ b/src/test/java/com/spaceclub/user/UserTestFixture.java
@@ -14,7 +14,7 @@ public class UserTestFixture {
                 .provider(Provider.KAKAO)
                 .email("abc@naver.com")
                 .refreshToken("refreshToken")
-                .image("www.image.com")
+                .profileImageUrl("www.image.com")
                 .build();
     }
 
@@ -27,7 +27,7 @@ public class UserTestFixture {
                 .provider(Provider.KAKAO)
                 .email("abc@naver.com")
                 .refreshToken("refreshToken")
-                .image("www.image.com")
+                .profileImageUrl("www.image.com")
                 .build();
     }
 

--- a/src/test/java/com/spaceclub/user/UserTestFixture.java
+++ b/src/test/java/com/spaceclub/user/UserTestFixture.java
@@ -8,7 +8,7 @@ public class UserTestFixture {
     public static User user1() {
         return User.builder()
                 .id(1L)
-                .nickname("멤버명")
+                .name("멤버명")
                 .phoneNumber("010-1234-5678")
                 .oauthId("1234")
                 .provider(Provider.KAKAO)
@@ -21,7 +21,7 @@ public class UserTestFixture {
     public static User user2() {
         return User.builder()
                 .id(2L)
-                .nickname("멤버명")
+                .name("멤버명")
                 .phoneNumber("010-1234-5678")
                 .oauthId("12345")
                 .provider(Provider.KAKAO)

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -93,7 +93,7 @@ class UserControllerTest {
                                         fieldWithPath("data[].title").type(STRING).description("이벤트 제목"),
                                         fieldWithPath("data[].location").type(STRING).description("이벤트 위치"),
                                         fieldWithPath("data[].clubName").type(STRING).description("이벤트 주최자"),
-                                        fieldWithPath("data[].poster").type(STRING).description("포스터 URL"),
+                                        fieldWithPath("data[].posterImageUrl").type(STRING).description("포스터 URL"),
                                         fieldWithPath("data[].startDate").type(STRING).description("이벤트 시작일"),
                                         fieldWithPath("data[].status").type(STRING).description("이벤트 상태"),
                                         fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),

--- a/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
+++ b/src/test/java/com/spaceclub/user/domain/RequiredInfoTest.java
@@ -17,26 +17,26 @@ class RequiredInfoTest {
     @ParameterizedTest(name = "{index}. value : {arguments}")
     @NullSource
     @ValueSource(strings = {"", " ", "    "})
-    void 닉네임이_null이거나_공백일_경우_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
+    void 이름이_null이거나_공백일_경우_필수정보_객체_생성에_생성에_실패한다(String invalidName) {
         // when, then
-        assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
+        assertThatThrownBy(() -> new RequiredInfo(invalidName, validPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @ParameterizedTest(name = "{index}. nickname : {arguments}")
+    @ParameterizedTest(name = "{index}. name : {arguments}")
     @ValueSource(strings = {"1", "가", "가나다라마바사아자차카", "12345678901", "가   "})
-    void 양끝_공백을_제거한_닉네임이_2글자이상_10글자이하_범위에서_벗어나면_필수정보_객체_생성에_생성에_실패한다(String invalidNickname) {
+    void 양끝_공백을_제거한_이름이_2글자이상_10글자이하_범위에서_벗어나면_필수정보_객체_생성에_생성에_실패한다(String invalidName) {
         // when, then
-        assertThatThrownBy(() -> new RequiredInfo(invalidNickname, validPhoneNumber))
+        assertThatThrownBy(() -> new RequiredInfo(invalidName, validPhoneNumber))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @ParameterizedTest(name = "{index}. nickname : {arguments}")
+    @ParameterizedTest(name = "{index}. name : {arguments}")
     @ValueSource(strings = {"가나", "     가나    ", "가  나"})
-    void 양끝_공백을_제거한_닉네임이_2글자이상_10글자이하_범위에_있으면_필수정보_객체_생성에_생성에_성공한다(String validNickname) {
+    void 양끝_공백을_제거한_이름이_2글자이상_10글자이하_범위에_있으면_필수정보_객체_생성에_생성에_성공한다(String validName) {
         // when, then
         assertThatNoException()
-                .isThrownBy(() -> new RequiredInfo(validNickname, validPhoneNumber));
+                .isThrownBy(() -> new RequiredInfo(validName, validPhoneNumber));
     }
 
 }


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-241](https://space-club.atlassian.net/browse/SKRB-241)
  <br>

### 🖥️ 작업 내용
- User의 `nickname`을 `name`으로 변경
- User의 `image`를 `profileImageUrl`로 변경
- Club의 `thumbnailUrl`를 `logoImageUrl`로 변경
- Event의 `poster`를 `posterImageUrl`로 변경
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
  <br>

### 📢 리뷰어 전달 사항

컬럼명 관련 수정사항이라 변경된 파일이 많습니다.
다 보기 힘드신 경우 작업 내용 명을 확인하시면 어떤 것을 변경했는지 확인 가능합니다!

**⭐슬랙에도 적어두었지만 현재 작업하고 있거나 작업 예정인 경우 컬럼명 변경 관련해서 꼭 확인하시고 지라를 통하여 프론트 담당자 분들에게 말씀드리길 바랍니다!⭐**


[SKRB-241]: https://space-club.atlassian.net/browse/SKRB-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ