### PR TITLE
[SKRB-226] feat: 토큰 헤더 적용 및 유저의 클럽 조회 API 도메인 이동

### DIFF
--- a/src/docs/asciidoc/club-api.adoc
+++ b/src/docs/asciidoc/club-api.adoc
@@ -84,19 +84,6 @@ include::{snippets}/club/join/path-parameters.adoc[]
 include::{snippets}/club/join/http-response.adoc[]
 :sectnums:
 
-=== 클럽 목록 조회
-:sectnums!:
-==== Request
-include::{snippets}/club/getAll/http-request.adoc[]
-===== Path Parameter
-include::{snippets}/club/getAll/path-parameters.adoc[]
-
-==== Response
-include::{snippets}/club/getAll/http-response.adoc[]
-===== Response Body
-include::{snippets}/club/getAll/response-fields.adoc[]
-:sectnums:
-
 === 클럽 조회
 :sectnums!:
 ==== Request

--- a/src/docs/asciidoc/event-api.adoc
+++ b/src/docs/asciidoc/event-api.adoc
@@ -1,47 +1,74 @@
 == 행사
+
 === 행사 개설
 :sectnums!:
 ==== Request
+
 include::{snippets}/event/create/http-request.adoc[]
 ===== Multipart Form Data
+
 include::{snippets}/event/create/request-parts.adoc[]
+
 ===== Request Form Data
+
 include::{snippets}/event/create/request-part-request-fields.adoc[]
+
 ==== Response
+
 include::{snippets}/event/create/http-response.adoc[]
 ===== ResponseHeader
+
 include::{snippets}/event/create/response-headers.adoc[]
 :sectnums:
 
 === 행사 신청
 :sectnums!:
 ==== Request
+
 include::{snippets}/event/apply/http-request.adoc[]
+===== Request Header
+
+include::{snippets}/event/apply/request-headers.adoc[]
+
+===== Request Body
+
 include::{snippets}/event/apply/request-fields.adoc[]
+
 ==== Response
+
 include::{snippets}/event/apply/http-response.adoc[]
 :sectnums:
 
 === 모든 행사 조회
 :sectnums!:
 ==== Request
+
 include::{snippets}/event/getAll/http-request.adoc[]
 ===== Query Parameter
+
 include::{snippets}/event/getAll/query-parameters.adoc[]
+
 ==== Response
+
 include::{snippets}/event/getAll/http-response.adoc[]
 ===== Response Body
+
 include::{snippets}/event/getAll/response-fields.adoc[]
 :sectnums:
 
 === 행사 상세 조회
 :sectnums!:
 ==== Request
+
 include::{snippets}/event/get/http-request.adoc[]
 ===== Path Parameter
+
 include::{snippets}/event/get/path-parameters.adoc[]
+
 ==== Response
+
 include::{snippets}/event/get/http-response.adoc[]
 ===== Response Body
+
 include::{snippets}/event/get/response-fields.adoc[]
 :sectnums:

--- a/src/docs/asciidoc/user-api.adoc
+++ b/src/docs/asciidoc/user-api.adoc
@@ -1,28 +1,40 @@
 == 유저
-=== 유저가 신청한 모든 이벤트 조회
+
+=== 유저가 신청한 모든 행사 조회
 :sectnums!:
 ==== Request
+
 include::{snippets}/user/getAllEvents/http-request.adoc[]
-===== Path Parameter
-include::{snippets}/user/getAllEvents/path-parameters.adoc[]
+===== Request Header
+
+include::{snippets}/user/getAllEvents/request-headers.adoc[]
+
 ===== Query Parameter
+
 include::{snippets}/user/getAllEvents/query-parameters.adoc[]
+
 ==== Response
+
 include::{snippets}/user/getAllEvents/http-response.adoc[]
 ===== Response Body
+
 include::{snippets}/user/getAllEvents/response-fields.adoc[]
 :sectnums:
 
 === 카카오 로그인으로 회원가입한 유저 - 신규 유저일 경우
 :sectnums!:
 ==== Request
+
 include::{snippets}/user/kakaoLoginNewUser/http-request.adoc[]
 ===== Request Body
+
 include::{snippets}/user/kakaoLoginNewUser/request-fields.adoc[]
 
 ==== Response
+
 include::{snippets}/user/kakaoLoginNewUser/http-response.adoc[]
 ===== Response Body
+
 include::{snippets}/user/kakaoLoginNewUser/response-fields.adoc[]
 :sectnums:
 

--- a/src/docs/asciidoc/user-api.adoc
+++ b/src/docs/asciidoc/user-api.adoc
@@ -105,3 +105,20 @@ include::{snippets}/user/getUserProfileImage/http-response.adoc[]
 
 include::{snippets}/user/getUserProfileImage/response-fields.adoc[]
 :sectnums:
+
+=== 유저의 클럽 목록 조회
+:sectnums!:
+==== Request
+
+include::{snippets}/user/getAllClubs/http-request.adoc[]
+===== Request Header
+
+include::{snippets}/user/getAllClubs/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/user/getAllClubs/http-response.adoc[]
+===== Response Body
+
+include::{snippets}/user/getAllClubs/response-fields.adoc[]
+:sectnums:

--- a/src/main/java/com/spaceclub/club/controller/ClubController.java
+++ b/src/main/java/com/spaceclub/club/controller/ClubController.java
@@ -12,6 +12,7 @@ import com.spaceclub.club.service.vo.ClubUserUpdate;
 import com.spaceclub.event.domain.Event;
 import com.spaceclub.global.S3ImageUploader;
 import com.spaceclub.global.dto.PageResponse;
+import com.spaceclub.global.jwt.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +34,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -136,17 +136,6 @@ public class ClubController {
     @PostMapping("/clubs/{clubId}/invite/{uuid}")
     public ResponseEntity<Void> joinClub(@PathVariable Long clubId, @PathVariable String uuid) {
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/clubs/all/{userId}")
-    public ResponseEntity<List<ClubGetAllResponse>> getAllClubs(@PathVariable Long userId) {
-        List<Club> clubs = service.getAllClubs(userId);
-
-        List<ClubGetAllResponse> clubResponses = clubs.stream()
-                .map(ClubGetAllResponse::from)
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(clubResponses);
     }
 
 }

--- a/src/main/java/com/spaceclub/club/service/ClubService.java
+++ b/src/main/java/com/spaceclub/club/service/ClubService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -96,14 +95,6 @@ public class ClubService {
         }
 
         return invitationCode;
-    }
-
-    public List<Club> getAllClubs(Long userId) {
-        List<ClubUser> clubUsers = clubUserRepository.findByUser_Id(userId);
-
-        return clubUsers.stream()
-                .map(ClubUser::getClub)
-                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -8,6 +8,8 @@ import com.spaceclub.event.domain.Event;
 import com.spaceclub.event.service.EventService;
 import com.spaceclub.global.S3ImageUploader;
 import com.spaceclub.global.dto.PageResponse;
+import com.spaceclub.global.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +37,8 @@ public class EventController {
 
     private final S3ImageUploader uploader;
 
+    private final JwtService jwtService;
+
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> create(@RequestPart EventCreateRequest request, @RequestPart MultipartFile posterImage) throws IOException {
         String posterImageUrl = uploader.uploadPosterImage(posterImage);
@@ -56,9 +60,10 @@ public class EventController {
     }
 
     @PostMapping("/apply")
-    public ResponseEntity<Void> applyEvent(@RequestBody EventApplyRequest request) {
+    public ResponseEntity<Void> applyEvent(@RequestBody EventApplyRequest request, HttpServletRequest servletRequest) {
         Long eventId = request.eventId();
-        Long userId = request.userId();
+        Long userId = jwtService.verifyUserId(servletRequest);
+
         eventService.applyEvent(eventId, userId);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/spaceclub/event/controller/dto/EventApplyRequest.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventApplyRequest.java
@@ -3,8 +3,7 @@ package com.spaceclub.event.controller.dto;
 import lombok.Builder;
 
 public record EventApplyRequest(
-        Long eventId,
-        Long userId
+        Long eventId
 ) {
 
     @Builder

--- a/src/main/java/com/spaceclub/user/controller/UserController.java
+++ b/src/main/java/com/spaceclub/user/controller/UserController.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,8 +39,9 @@ public class UserController {
 
     private final JwtService jwtService;
 
-    @GetMapping("/{userId}/events")
-    public PageResponse<UserEventGetResponse, Event> getAllEvents(@PathVariable Long userId, Pageable pageable) {
+    @GetMapping("/events")
+    public PageResponse<UserEventGetResponse, Event> getAllEvents(Pageable pageable, HttpServletRequest servletRequest) {
+        Long userId = jwtService.verifyUserId(servletRequest);
         Page<Event> eventPages = userService.findAllEventPages(userId, pageable);
 
         List<UserEventGetResponse> eventGetResponse = eventPages.getContent().stream()

--- a/src/main/java/com/spaceclub/user/controller/UserController.java
+++ b/src/main/java/com/spaceclub/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.spaceclub.user.controller;
 
+import com.spaceclub.club.controller.ClubGetAllResponse;
+import com.spaceclub.club.domain.Club;
 import com.spaceclub.event.domain.Event;
 import com.spaceclub.global.dto.PageResponse;
 import com.spaceclub.global.jwt.service.JwtService;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.spaceclub.user.controller.dto.UserEventGetResponse.from;
 
@@ -89,6 +92,18 @@ public class UserController {
         Long userId = jwtService.verifyUserId(request);
 
         return new UserProfileImageResponse(userService.getUserProfileImage(userId));
+    }
+
+    @GetMapping("/clubs")
+    public ResponseEntity<List<ClubGetAllResponse>> getClubs(HttpServletRequest servletRequest) {
+        Long userId = jwtService.verifyUserId(servletRequest);
+        List<Club> clubs = userService.getClubs(userId);
+
+        List<ClubGetAllResponse> clubResponses = clubs.stream()
+                .map(ClubGetAllResponse::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(clubResponses);
     }
 
 }

--- a/src/main/java/com/spaceclub/user/service/UserService.java
+++ b/src/main/java/com/spaceclub/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.spaceclub.user.service;
 
+import com.spaceclub.club.domain.Club;
+import com.spaceclub.club.domain.ClubUser;
+import com.spaceclub.club.repository.ClubUserRepository;
 import com.spaceclub.event.domain.Event;
 import com.spaceclub.event.repository.EventUserRepository;
 import com.spaceclub.global.oauth.config.KakaoOauthInfoSender;
@@ -17,6 +20,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -25,6 +31,8 @@ public class UserService {
     private final KakaoOauthInfoSender kakaoOauthInfoSender;
 
     private final EventUserRepository eventUserRepository;
+
+    private final ClubUserRepository clubUserRepository;
 
     private final UserRepository userRepository;
 
@@ -67,6 +75,14 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
 
         return user.getProfileImageUrl();
+    }
+
+    public List<Club> getClubs(Long userId) {
+        List<ClubUser> clubUsers = clubUserRepository.findByUser_Id(userId);
+
+        return clubUsers.stream()
+                .map(ClubUser::getClub)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -6,7 +6,6 @@ import com.spaceclub.club.InvitationCodeGenerator;
 import com.spaceclub.club.controller.dto.ClubCreateRequest;
 import com.spaceclub.club.controller.dto.ClubUserUpdateRequest;
 import com.spaceclub.club.domain.Club;
-import com.spaceclub.club.domain.ClubNotice;
 import com.spaceclub.club.domain.ClubUserRole;
 import com.spaceclub.club.service.ClubService;
 import com.spaceclub.club.service.vo.ClubUserUpdate;
@@ -32,7 +31,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.spaceclub.club.ClubTestFixture.club1;
-import static com.spaceclub.club.ClubTestFixture.club2;
 import static com.spaceclub.club.ClubUserTestFixture.club1User1Manager;
 import static com.spaceclub.club.ClubUserTestFixture.club1User2Manager;
 import static com.spaceclub.event.EventTestFixture.event1;
@@ -394,7 +392,7 @@ class ClubControllerTest {
         // when
         ResultActions actions =
                 mockMvc.perform(post("/api/v1/clubs/{clubId}/invite/{uuid}", clubId, uuid)
-                .with(csrf()));
+                        .with(csrf()));
 
         // then
         actions.andExpect(status().isNoContent())
@@ -407,34 +405,6 @@ class ClubControllerTest {
                                 parameterWithName("uuid").description("클럽 초대 링크 식별자")
                         )));
 
-    }
-
-    @Test
-    @WithMockUser
-    void 모든_클럽_조회에_성공한다() throws Exception {
-        // given
-        Long userId = 1L;
-        given(clubService.getAllClubs(1L)).willReturn(List.of(club1(), club2()));
-
-        // when
-        ResultActions actions = mockMvc.perform(get("/api/v1/clubs/all/{userId}", userId));
-
-        // then
-        actions.andExpect(status().isOk())
-                .andDo(print())
-                .andDo(document("club/getAll",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        pathParameters(
-                                parameterWithName("userId").description("유저 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("[]").type(ARRAY).description("클럽"),
-                                fieldWithPath("[].id").type(NUMBER).description("클럽 아이디"),
-                                fieldWithPath("[].logoImageUrl").type(STRING).description("클럽 이미지 Url"),
-                                fieldWithPath("[].name").type(STRING).description("클럽 이름")
-                        )
-                ));
     }
 
 }

--- a/src/test/java/com/spaceclub/club/service/ClubServiceTest.java
+++ b/src/test/java/com/spaceclub/club/service/ClubServiceTest.java
@@ -38,6 +38,9 @@ class ClubServiceTest {
     @Mock
     private ClubRepository clubRepository;
 
+    @Mock
+    private ClubUserRepository clubUserRepository;
+
     private final ClubUserUpdate clubUserUpdate = ClubUserUpdate.builder()
             .clubId(club1().getId())
             .memberId(user1().getId())
@@ -87,9 +90,6 @@ class ClubServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
 
     }
-
-    @Mock
-    private ClubUserRepository clubUserRepository;
 
     @Test
     void 클럽_멤버_권한_수정에_성공한다() {
@@ -146,18 +146,6 @@ class ClubServiceTest {
         // when, then
         assertThatThrownBy(() -> clubService.deleteMember(club1().getId(), user1().getId()))
                 .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void 모든_클럽_조회에_성공한다() {
-        // given
-        given(clubUserRepository.findByUser_Id(user1().getId())).willReturn(List.of(club1User1Manager()));
-
-        // when
-        List<Club> clubs = clubService.getAllClubs(user1().getId());
-
-        // then
-        assertThat(clubs).usingRecursiveComparison().isEqualTo(List.of(club1()));
     }
 
 }

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -22,10 +22,13 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
 import java.util.Map;
 
+import static com.spaceclub.club.ClubTestFixture.club1;
+import static com.spaceclub.club.ClubTestFixture.club2;
 import static com.spaceclub.event.EventTestFixture.event1;
 import static com.spaceclub.event.EventTestFixture.event2;
 import static com.spaceclub.event.EventTestFixture.event3;
@@ -303,6 +306,37 @@ class UserControllerTest {
                                 )
                         )
                 );
+    }
+
+
+    @Test
+    @WithMockUser
+    void 유저의_모든_클럽_조회에_성공한다() throws Exception {
+        // given
+        given(jwtService.verifyUserId(any())).willReturn(1L);
+        given(userService.getClubs(1L)).willReturn(List.of(club1(), club2()));
+
+        // when
+        ResultActions actions = mvc.perform(get("/api/v1/users/clubs")
+                .header("Authorization", "access token")
+        );
+
+        // then
+        actions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("user/getAllClubs",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("[]").type(ARRAY).description("클럽"),
+                                fieldWithPath("[].id").type(NUMBER).description("클럽 아이디"),
+                                fieldWithPath("[].logoImageUrl").type(STRING).description("클럽 이미지 Url"),
+                                fieldWithPath("[].name").type(STRING).description("클럽 이름")
+                        )
+                ));
     }
 
 }

--- a/src/test/java/com/spaceclub/user/service/UserServiceTest.java
+++ b/src/test/java/com/spaceclub/user/service/UserServiceTest.java
@@ -1,0 +1,45 @@
+package com.spaceclub.user.service;
+
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import com.spaceclub.club.domain.Club;
+import com.spaceclub.club.repository.ClubUserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.spaceclub.club.ClubTestFixture.club1;
+import static com.spaceclub.club.ClubUserTestFixture.club1User1Manager;
+import static com.spaceclub.user.UserTestFixture.user1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
+class UserServiceTest {
+
+    @Mock
+    private ClubUserRepository clubUserRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+
+    @Test
+    void 모든_클럽_조회에_성공한다() {
+        // given
+        given(clubUserRepository.findByUser_Id(user1().getId())).willReturn(List.of(club1User1Manager()));
+
+        // when
+        List<Club> clubs = userService.getClubs(user1().getId());
+
+        // then
+        assertThat(clubs).usingRecursiveComparison().isEqualTo(List.of(club1()));
+    }
+
+
+}


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-226](https://space-club.atlassian.net/browse/SKRB-226)
  <br>

### 🖥️ 작업 내용
- 행사 신청 API 토큰 헤더 적용
- 유저가 신청한 모든 이벤트 조회 API 토큰 헤더 적용
- 유저의 클럽 조회 API 토큰 헤더 적용 및 도메인 이동
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
  <br>

### 📢 리뷰어 전달 사항

@choi5798 행사 신청 API에 토큰 헤더 적용시켰습니다.
@juno-junho 유저가 신청한 모든 이벤트 조회 API에 토큰 헤더 적용시켰습니다.

**앞 PR위에 추가한 내용이라 파일 변경 수가 많습니다. 참고 부탁드려요.**

참고) 특정 커밋만 확인하는 방법(shift누르면 여러 개 선택 가능)
<img src="https://github.com/Space-Club/Backend/assets/63945197/82ebead1-d9c8-4ef0-a25c-98fdd0820a37"  width="300" height="400"/>

[SKRB-226]: https://space-club.atlassian.net/browse/SKRB-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ