### PR TITLE
[SKRB-328] fix: bookmark 설정, 취소시 로직 수정

### DIFF
--- a/src/main/java/com/spaceclub/user/domain/Bookmark.java
+++ b/src/main/java/com/spaceclub/user/domain/Bookmark.java
@@ -26,8 +26,6 @@ public class Bookmark {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    private boolean bookmarkStatus;
-
     @ManyToOne(fetch = EAGER, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -37,10 +35,9 @@ public class Bookmark {
     private Event event;
 
     @Builder
-    private Bookmark(Long id, boolean bookmarkStatus, User user, Event event) {
+    private Bookmark(Long id, User user, Event event) {
         validate(user, event);
         this.id = id;
-        this.bookmarkStatus = bookmarkStatus;
         this.user = user;
         this.event = event;
     }
@@ -48,11 +45,6 @@ public class Bookmark {
     private void validate(User user, Event event) {
         Assert.notNull(user, "유저는 필수입니다.");
         Assert.notNull(event, "이벤트는 필수입니다.");
-    }
-
-    public Bookmark changeBookmarkStatus(boolean bookmarkStatus) {
-        this.bookmarkStatus = bookmarkStatus;
-        return this;
     }
 
 }

--- a/src/main/java/com/spaceclub/user/repository/BookmarkRepository.java
+++ b/src/main/java/com/spaceclub/user/repository/BookmarkRepository.java
@@ -15,7 +15,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
         Optional<Bookmark> findByUserIdAndEventId(Long userId, Long eventId);
 
-        @Query("select b.event from Bookmark b where b.user = :user and b.bookmarkStatus = true")
+        @Query("select b.event from Bookmark b where b.user = :user")
         Page<Event> findBookmarkedEventPages(@Param("user") User user, Pageable pageable);
 
 }

--- a/src/main/java/com/spaceclub/user/service/UserService.java
+++ b/src/main/java/com/spaceclub/user/service/UserService.java
@@ -108,12 +108,11 @@ public class UserService {
         User user = getUser(userBookmarkInfo.userId());
 
         if (userBookmarkInfo.bookmarkStatus()) {
-            Bookmark build = Bookmark.builder()
+            Bookmark bookmark = Bookmark.builder()
                     .user(user)
                     .event(event)
-                    .bookmarkStatus(true)
                     .build();
-            bookmarkRepository.save(build);
+            bookmarkRepository.save(bookmark);
             return;
         }
 

--- a/src/test/java/com/spaceclub/user/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/spaceclub/user/repository/BookmarkRepositoryTest.java
@@ -71,19 +71,16 @@ class BookmarkRepositoryTest {
                 .id(1L)
                 .user(user)
                 .event(event1())
-                .bookmarkStatus(true)
                 .build();
         Bookmark bookmarkEvent2 = Bookmark.builder()
                 .id(2L)
                 .user(user)
                 .event(event2())
-                .bookmarkStatus(false)
                 .build();
         Bookmark bookmarkEvent3 = Bookmark.builder()
                 .id(3L)
                 .user(user)
                 .event(event3())
-                .bookmarkStatus(true)
                 .build();
         bookmarkRepository.saveAll(List.of(bookmarkEvent1, bookmarkEvent2, bookmarkEvent3));
     }
@@ -100,10 +97,10 @@ class BookmarkRepositoryTest {
         // then
         assertAll(
                 () -> assertThat(bookmarkedEventPages.getTotalElements())
-                        .isEqualTo(2),
+                        .isEqualTo(3),
                 () -> assertThat(bookmarkedEventPages.getContent())
                         .extracting(Event::getId)
-                        .containsExactlyInAnyOrder(1L, 3L)
+                        .containsExactlyInAnyOrder(1L, 2L, 3L)
         );
     }
 


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-328](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-328)
  <br>

### 🖥️ 작업 내용
- 북마크 테이블 변경 및 로직 수정
<br>

### ✅ PR시 확인 사항
- [ ] Linear History 여부
- [ ] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항

로직은 다음과 같아요
- event Id, user Id, bookmark 설정 여부 (true, false)를 받는다
- 유효한 Event 및 유효한 User인지 검증

1. bookmark 상태가 true인 경우
  - 북마크 테이블에 event id, bookmark id 생성
2. bookmark 상태가 false인 경우
  - 북마크 테이블에서 해당 row 삭제

develop 테이블 또한 수정했습니다


[SKRB-328]: https://space-club.atlassian.net/browse/SKRB-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ