### PR TITLE
[SRKB-170] feat: 로그인 및 회원가입 시 refresh token 발급 기능 구현

### DIFF
--- a/src/main/java/com/spaceclub/global/config/WebConfig.java
+++ b/src/main/java/com/spaceclub/global/config/WebConfig.java
@@ -29,8 +29,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAccessTokenInterceptor)
-                .addPathPatterns("/api/v1/**")
-                .excludePathPatterns("/api/v1/users/auths/**"); //  path 추후 변경 예정
+                .addPathPatterns("**/api/v1/**")
+                .excludePathPatterns("**/api/v1/users", "**/v1/users/oauths"); //  path 추후 변경 예정
     }
 
 }

--- a/src/main/java/com/spaceclub/user/controller/UserController.java
+++ b/src/main/java/com/spaceclub/user/controller/UserController.java
@@ -63,28 +63,28 @@ public class UserController {
     }
 
     @PostMapping
-    public ResponseEntity<UserLoginResponse> updateRequiredInfo(@RequestBody UserRequiredInfoRequest request) {//유저 찾기
+    public ResponseEntity<UserLoginResponse> createAccount(@RequestBody UserRequiredInfoRequest request) {
         User user = userService.updateRequiredInfo(request.userId(), new UserRequiredInfo(request.name(), request.phoneNumber()));
+
         String accessToken = jwtManager.createAccessToken(user.getId(), user.getUsername());
+        String refreshToken = jwtManager.createRefreshToken(user.getId());
 
         return ResponseEntity.created(URI.create("/api/v1/users/" + user.getId()))
-                .body(UserLoginResponse.from(user.getId(), accessToken));
+                .body(UserLoginResponse.from(user.getId(), accessToken, refreshToken));
     }
-
 
     @PostMapping("/oauths")
     public UserLoginResponse loginUser(@RequestBody UserCodeRequest userCodeRequest) {
         User kakaoUser = userService.createKakaoUser(userCodeRequest.code());
 
-        // 신규 유저면 빈 access token
         if (kakaoUser.isNewMember()) {
-            return UserLoginResponse.from(kakaoUser.getId(), "");
+            return UserLoginResponse.from(kakaoUser.getId(), "", "");
         }
 
-        // 기존 유저면 jwt
         String accessToken = jwtManager.createAccessToken(kakaoUser.getId(), kakaoUser.getUsername());
+        String refreshToken = jwtManager.createRefreshToken(kakaoUser.getId());
 
-        return UserLoginResponse.from(kakaoUser.getId(), accessToken);
+        return UserLoginResponse.from(kakaoUser.getId(), accessToken, refreshToken);
     }
 
 

--- a/src/main/java/com/spaceclub/user/controller/dto/UserLoginResponse.java
+++ b/src/main/java/com/spaceclub/user/controller/dto/UserLoginResponse.java
@@ -1,9 +1,9 @@
 package com.spaceclub.user.controller.dto;
 
-public record UserLoginResponse(Long userId, String accessToken) {
+public record UserLoginResponse(Long userId, String accessToken, String refreshToken) {
 
-    public static UserLoginResponse from(Long userId, String accessToken) {
-        return new UserLoginResponse(userId, accessToken);
+    public static UserLoginResponse from(Long userId, String accessToken, String refreshToken) {
+        return new UserLoginResponse(userId, accessToken, refreshToken);
     }
 
 }

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -66,6 +66,30 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<FormOptionUser> formOptionUsers = new ArrayList<>();
 
+    private User(
+            Long id,
+            RequiredInfo requiredInfo,
+            Status status,
+            String oauthUserName,
+            Provider provider,
+            Email email,
+            String refreshToken,
+            String profileImageUrl,
+            List<EventUser> events,
+            List<FormOptionUser> formOptionUsers
+    ) {
+        this.id = id;
+        this.requiredInfo = requiredInfo;
+        this.status = status;
+        this.oauthUserName = oauthUserName;
+        this.provider = provider;
+        this.email = email;
+        this.refreshToken = refreshToken;
+        this.profileImageUrl = profileImageUrl;
+        this.events = events;
+        this.formOptionUsers = formOptionUsers;
+    }
+
     @Builder
     private User(
             Long id,
@@ -133,9 +157,34 @@ public class User {
 
     public User changeProfileImageUrl(String profileUrl) {
         if (profileUrl == null) throw new IllegalArgumentException("프로필 이미지는 null이 될 수 없습니다.");
-        this.profileImageUrl = profileUrl;
+        return new User(
+                this.id,
+                this.requiredInfo,
+                this.status,
+                this.oauthUserName,
+                this.provider,
+                this.email,
+                refreshToken,
+                profileUrl,
+                this.events,
+                this.formOptionUsers
+        );
+    }
 
-        return this;
+    public User updateRefreshToken(String refreshToken) {
+
+        return new User(
+                this.id,
+                this.requiredInfo,
+                this.status,
+                this.oauthUserName,
+                this.provider,
+                this.email,
+                refreshToken,
+                this.profileImageUrl,
+                this.events,
+                this.formOptionUsers
+        );
     }
 
 }

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -198,7 +198,8 @@ class UserControllerTest {
                                 ),
                                 responseFields(
                                         fieldWithPath("userId").type(NUMBER).description("유저 ID"),
-                                        fieldWithPath("accessToken").type(STRING).description("access token")
+                                        fieldWithPath("accessToken").type(STRING).description("access token"),
+                                        fieldWithPath("refreshToken").type(STRING).description("refresh token")
                                 )
                         )
                 );
@@ -210,8 +211,11 @@ class UserControllerTest {
         //given
         User newUser = UserTestFixture.user2();
         given(userService.createKakaoUser(any())).willReturn(newUser);
+
         final String accessToken = "generated access token";
+        final String refreshToken = "generated refresh token";
         given(jwtManager.createAccessToken(any(Long.class), any(String.class))).willReturn(accessToken);
+        given(jwtManager.createRefreshToken(any(Long.class))).willReturn(refreshToken);
 
         // when, then
         mvc.perform(post("/api/v1/users/oauths")
@@ -222,6 +226,7 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("userId").value(newUser.getId()))
                 .andExpect(jsonPath("accessToken").value(accessToken))
+                .andExpect(jsonPath("refreshToken").value(refreshToken))
                 .andDo(
                         document("user/kakaoLoginExistingUser",
                                 preprocessRequest(prettyPrint()),
@@ -231,7 +236,8 @@ class UserControllerTest {
                                 ),
                                 responseFields(
                                         fieldWithPath("userId").type(NUMBER).description("유저 ID"),
-                                        fieldWithPath("accessToken").type(STRING).description("access token")
+                                        fieldWithPath("accessToken").type(STRING).description("access token"),
+                                        fieldWithPath("refreshToken").type(STRING).description("refresh token")
                                 )
                         )
                 );
@@ -244,9 +250,10 @@ class UserControllerTest {
         UserRequiredInfoRequest request = new UserRequiredInfoRequest(2L, "name", "010-1234-5678");
         final User savedUser = UserTestFixture.user2();
         final String accessToken = "generated access token";
+        final String refreshToken = "generated refresh token";
         given(userService.updateRequiredInfo(any(), any(UserRequiredInfo.class))).willReturn(savedUser);
         given(jwtManager.createAccessToken(any(Long.class), any(String.class))).willReturn(accessToken);
-
+        given(jwtManager.createRefreshToken(any(Long.class))).willReturn(refreshToken);
         // when, then
         mvc.perform(post("/api/v1/users")
                         .content(mapper.writeValueAsString(request))
@@ -270,7 +277,8 @@ class UserControllerTest {
                                 ),
                                 responseFields(
                                         fieldWithPath("userId").type(NUMBER).description("유저 ID"),
-                                        fieldWithPath("accessToken").type(STRING).description("access token")
+                                        fieldWithPath("accessToken").type(STRING).description("access token"),
+                                        fieldWithPath("refreshToken").type(STRING).description("refresh token")
                                 )
                         )
                 );


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SRKB-170](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-170)
  <br>

### 🖥️ 작업 내용
- 회원 가입 및 로그인 시 refresh token 발급 기능 구현
- 발급 시에는 user 테이블의 db 컬럼을 update합니다.
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부 
<img width="1223" alt="image" src="https://github.com/Space-Club/Backend/assets/72647031/84e1c9ee-5a0d-4471-9ece-55119e161a1c">

  <br>

### 📢 리뷰어 전달 사항

마지막 두 커밋만 보면 됩니다