### PR TITLE
[SKRB-340] feat: argument resolver로 인증 관련 controller 공통 관심사 분리

### DIFF
--- a/src/main/java/com/spaceclub/global/Authenticated.java
+++ b/src/main/java/com/spaceclub/global/Authenticated.java
@@ -1,0 +1,11 @@
+package com.spaceclub.global;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+public @interface Authenticated {
+
+}

--- a/src/main/java/com/spaceclub/global/UserArgumentResolver.java
+++ b/src/main/java/com/spaceclub/global/UserArgumentResolver.java
@@ -17,8 +17,8 @@ import java.util.Objects;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
-@Component
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class UserArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -36,7 +36,7 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter,
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) throws Exception {
+                                  WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
         String accessToken = Objects.requireNonNull(request)

--- a/src/main/java/com/spaceclub/global/UserArgumentResolver.java
+++ b/src/main/java/com/spaceclub/global/UserArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.spaceclub.global;
+
+import com.spaceclub.global.jwt.Claims;
+import com.spaceclub.global.jwt.service.JwtManager;
+import com.spaceclub.global.jwt.vo.JwtUser;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Objects;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final static String TOKEN_PREFIX ="Bearer ";
+
+    private final JwtManager jwtManager;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return JwtUser.class.isAssignableFrom(parameter.getParameterType()) &&
+                parameter.hasParameterAnnotation(Authenticated.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        String accessToken = Objects.requireNonNull(request)
+                .getHeader(AUTHORIZATION)
+                .replace(TOKEN_PREFIX, "");
+
+        Claims claims = jwtManager.getClaims(accessToken);
+
+        return new JwtUser(claims.getId(), claims.getUsername());
+    }
+
+}

--- a/src/main/java/com/spaceclub/global/config/WebConfig.java
+++ b/src/main/java/com/spaceclub/global/config/WebConfig.java
@@ -1,12 +1,16 @@
 package com.spaceclub.global.config;
 
+import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Profile(value = {"develop", "local"})
 @Configuration
@@ -14,6 +18,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final JwtAuthorizationInterceptor jwtAccessTokenInterceptor;
+    private final UserArgumentResolver userArgumentResolver;
 
     @Profile("develop")
     @Override
@@ -30,7 +35,15 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAccessTokenInterceptor)
                 .addPathPatterns("**/api/v1/**")
-                .excludePathPatterns("**/api/v1/users", "**/v1/users/oauths"); //  path 추후 변경 예정
+                .excludePathPatterns(
+                        "**/api/v1/users",
+                        "**/api/v1/users/oauths",
+                        "**/api/v1/clubs/invite/"); //  path 추후 변경 예정
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userArgumentResolver);
     }
 
 }

--- a/src/main/java/com/spaceclub/global/jwt/service/JwtManager.java
+++ b/src/main/java/com/spaceclub/global/jwt/service/JwtManager.java
@@ -35,6 +35,7 @@ public class JwtManager {
         return refreshToken;
     }
 
+
     public Long verifyUserId(HttpServletRequest request) {
         String header = request.getHeader(AUTHORIZATION);
 

--- a/src/main/java/com/spaceclub/invite/controller/InviteController.java
+++ b/src/main/java/com/spaceclub/invite/controller/InviteController.java
@@ -2,10 +2,10 @@ package com.spaceclub.invite.controller;
 
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.club.service.ClubService;
-import com.spaceclub.global.jwt.service.JwtManager;
+import com.spaceclub.global.Authenticated;
+import com.spaceclub.global.jwt.vo.JwtUser;
 import com.spaceclub.invite.controller.dto.ClubRequestToJoinResponse;
 import com.spaceclub.invite.service.InviteService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,13 +27,10 @@ public class InviteController {
 
     private final ClubService clubService;
 
-    private final JwtManager jwtManager;
-
     @PostMapping("/clubs/{clubId}/invite")
-    public ResponseEntity<Map<String, String>> getInviteLink(@PathVariable Long clubId, HttpServletRequest httpServletRequest) {
-        Long userId = jwtManager.verifyUserId(httpServletRequest);
+    public ResponseEntity<Map<String, String>> getInviteLink(@PathVariable Long clubId, @Authenticated JwtUser jwtUser) {
 
-        String inviteCode = service.getInviteCode(clubId, userId);
+        String inviteCode = service.getInviteCode(clubId, jwtUser.id());
 
         String inviteLink = INVITE_LINK_PREFIX + inviteCode;
 
@@ -43,10 +40,9 @@ public class InviteController {
     }
 
     @PostMapping("/clubs/invite/{code}")
-    public ResponseEntity<Map<String, Long>> joinClub(@PathVariable String code, HttpServletRequest httpServletRequest) {
-        Long userId = jwtManager.verifyUserId(httpServletRequest);
+    public ResponseEntity<Map<String, Long>> joinClub(@PathVariable String code, @Authenticated JwtUser jwtUser) {
 
-        Long clubId = service.joinClub(code, userId);
+        Long clubId = service.joinClub(code, jwtUser.id());
 
         return ResponseEntity.ok(
                 Map.of("clubId", clubId)

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -187,4 +187,10 @@ public class User {
         );
     }
 
+    public User updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+
+        return this;
+    }
+
 }

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -157,6 +157,7 @@ public class User {
 
     public User changeProfileImageUrl(String profileUrl) {
         if (profileUrl == null) throw new IllegalArgumentException("프로필 이미지는 null이 될 수 없습니다.");
+
         return new User(
                 this.id,
                 this.requiredInfo,
@@ -172,7 +173,6 @@ public class User {
     }
 
     public User updateRefreshToken(String refreshToken) {
-
         return new User(
                 this.id,
                 this.requiredInfo,
@@ -185,12 +185,6 @@ public class User {
                 this.events,
                 this.formOptionUsers
         );
-    }
-
-    public User updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-
-        return this;
     }
 
 }

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -12,8 +12,8 @@ import com.spaceclub.club.service.ClubService;
 import com.spaceclub.club.service.vo.ClubNoticeUpdate;
 import com.spaceclub.club.service.vo.ClubUserUpdate;
 import com.spaceclub.event.domain.Event;
+import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
-import com.spaceclub.global.jwt.service.JwtManager;
 import com.spaceclub.invite.service.InviteService;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
@@ -106,13 +106,14 @@ class ClubControllerTest {
     private InviteService inviteService;
 
     @MockBean
-    private JwtManager jwtManager;
+    private UserArgumentResolver userArgumentResolver;
 
     @Test
     @WithMockUser
     void 클럽_생성에_성공한다() throws Exception {
+
         // given
-        given(clubService.createClub(any(Club.class), any(Long.class), any(MultipartFile.class))).willReturn(
+        given(clubService.createClub(any(Club.class), any(), any(MultipartFile.class))).willReturn(
                 Club.builder()
                         .id(1L)
                         .name("연사모")
@@ -180,14 +181,12 @@ class ClubControllerTest {
     @WithMockUser
     void 클럽_조회에_성공한다() throws Exception {
         // given
-        Long userId = 1L;
         given(clubService.getClub(any(Long.class))).willReturn(club1());
-        given(jwtManager.verifyUserId(any())).willReturn(userId);
-        given(clubService.getUserRole(any(Long.class), any(Long.class))).willReturn(MANAGER.name());
+        given(clubService.getUserRole(any(Long.class), any())).willReturn(MANAGER.name());
 
         // when
         ResultActions result = this.mockMvc.perform(get("/api/v1/clubs/{clubId}", club1().getId())
-                .header(AUTHORIZATION, "Acess Token")
+                .header(AUTHORIZATION, "Access Token")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -495,7 +494,7 @@ class ClubControllerTest {
     void 클럽_공지사항_조회에_성공한다() throws Exception {
         // given
         Long clubId = 1L;
-        given(clubService.getNotices(any(Long.class), any(Long.class))).willReturn(
+        given(clubService.getNotices(any(Long.class), any())).willReturn(
                 List.of(clubNotice1(), clubNotice2())
         );
 
@@ -601,7 +600,7 @@ class ClubControllerTest {
     void 클럽_일정_조회에_성공한다() throws Exception {
         // given
         Long clubId = 1L;
-        given(clubService.getClubSchedules(any(Long.class), any(Long.class))).willReturn(
+        given(clubService.getClubSchedules(any(Long.class), any())).willReturn(
                 List.of(clubEvent())
         );
         given(clubService.getManagerProfileImageUrl(any(Long.class))).willReturn("profileImageUrl");

--- a/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
@@ -17,9 +17,8 @@ import com.spaceclub.event.service.EventService;
 import com.spaceclub.event.service.vo.EventApplicationCreateInfo;
 import com.spaceclub.form.FormTestFixture;
 import com.spaceclub.global.S3ImageUploader;
+import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
-import com.spaceclub.global.jwt.service.JwtManager;
-import com.spaceclub.user.controller.UserController;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,10 +112,10 @@ class EventControllerTest {
     private EventService eventService;
 
     @MockBean
-    private JwtManager jwtManager;
+    private S3ImageUploader uploader;
 
     @MockBean
-    private S3ImageUploader uploader;
+    private UserArgumentResolver userArgumentResolver;
 
     private final MockMultipartFile posterImage = new MockMultipartFile(
             "posterImage",
@@ -1095,7 +1094,7 @@ class EventControllerTest {
     @WithMockUser
     void 행사_참여_신청_취소에_성공한다() throws Exception {
         // given
-        given(eventService.cancelEvent(any(Long.class), any(Long.class))).willReturn(CANCELED);
+        given(eventService.cancelEvent(any(Long.class), any())).willReturn(CANCELED);
 
         // when
         ResultActions actions = mvc.perform(delete("/api/v1/events/{eventId}/applications", 1L)
@@ -1128,8 +1127,7 @@ class EventControllerTest {
         List<Event> events = List.of(event1(), showEvent(), clubEvent());
         Page<Event> eventPages = new PageImpl<>(events);
 
-        given(jwtManager.verifyUserId(any())).willReturn(1L);
-        given(eventService.getSearchEvents(any(String.class), any(Pageable.class), any(Long.class))).willReturn(eventPages);
+        given(eventService.getSearchEvents(any(String.class), any(Pageable.class), any())).willReturn(eventPages);
 
         // when
         ResultActions actions = mvc.perform(get("/api/v1/events/searches")
@@ -1194,8 +1192,7 @@ class EventControllerTest {
     @WithMockUser
     public void 행사_삭제에_성공한다() throws Exception {
         // given
-        given(jwtManager.verifyUserId(any())).willReturn(1L);
-        doNothing().when(eventService).delete(any(Long.class), any(Long.class));
+        doNothing().when(eventService).delete(any(Long.class), any());
 
         // when
         ResultActions actions = mvc.perform(delete("/api/v1/events/{eventId}", 1L)
@@ -1232,7 +1229,6 @@ class EventControllerTest {
                 .build();
 
         Long userId = 1L;
-        given(jwtManager.verifyUserId(any())).willReturn(userId);
         doNothing().when(eventService).createApplicationForm(EventApplicationCreateInfo.builder()
                 .userId(userId)
                 .eventId(request.eventId())

--- a/src/test/java/com/spaceclub/form/controller/FormControllerTest.java
+++ b/src/test/java/com/spaceclub/form/controller/FormControllerTest.java
@@ -11,9 +11,8 @@ import com.spaceclub.form.service.FormService;
 import com.spaceclub.form.service.vo.FormApplicationGetInfo;
 import com.spaceclub.form.service.vo.FormCreate;
 import com.spaceclub.form.service.vo.FormGet;
+import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
-import com.spaceclub.global.jwt.service.JwtManager;
-import com.spaceclub.user.controller.UserController;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,7 +80,7 @@ class FormControllerTest {
     private FormService formService;
 
     @MockBean
-    private JwtManager jwtManager;
+    private UserArgumentResolver userArgumentResolver;
 
     @Test
     @WithMockUser
@@ -94,8 +93,6 @@ class FormControllerTest {
         FormCreateRequest formCreateRequest = new FormCreateRequest(1L, "행사에 대한 폼 양식입니다.", true, items);
 
         Long eventId = 1L;
-        Long userId = 1L;
-        given(jwtManager.verifyUserId(any())).willReturn(userId);
         given(formService.createForm(any(FormCreate.class))).willReturn(eventId);
 
         // when, then
@@ -140,10 +137,7 @@ class FormControllerTest {
                 .form(form)
                 .user(user1())
                 .build();
-
-        Long userId = 1L;
-        given(jwtManager.verifyUserId(any())).willReturn(userId);
-        given(formService.getForm(any(Long.class), any(Long.class))).willReturn(formGet);
+        given(formService.getForm(any(), any(Long.class))).willReturn(formGet);
 
         // when, then
         mvc.perform(get("/api/v1/events/{eventId}/forms", 1L)
@@ -187,8 +181,7 @@ class FormControllerTest {
         FormApplicationGetInfo formApplicationGetInfo = new FormApplicationGetInfo(form, List.of(FormTestFixture.formOptionUser1(), FormTestFixture.formOptionUser2()), eventUserPages);
 
         Long userId = 1L;
-        given(jwtManager.verifyUserId(any())).willReturn(userId);
-        given(formService.getApplicationForms(any(Long.class), any(Long.class), any(Pageable.class))).willReturn(formApplicationGetInfo);
+        given(formService.getApplicationForms(any(), any(Long.class), any(Pageable.class))).willReturn(formApplicationGetInfo);
 
         // when, then
         mvc.perform(get("/api/v1/events/{eventId}/forms/applications", 1L)

--- a/src/test/java/com/spaceclub/invite/controller/InviteControllerTest.java
+++ b/src/test/java/com/spaceclub/invite/controller/InviteControllerTest.java
@@ -3,10 +3,9 @@ package com.spaceclub.invite.controller;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.club.service.ClubService;
+import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
-import com.spaceclub.global.jwt.service.JwtManager;
 import com.spaceclub.invite.service.InviteService;
-import com.spaceclub.user.controller.UserController;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +61,7 @@ class InviteControllerTest {
     private ClubService clubService;
 
     @MockBean
-    private JwtManager jwtManager;
+    private UserArgumentResolver userArgumentResolver;
 
     @Test
     @WithMockUser
@@ -71,7 +70,7 @@ class InviteControllerTest {
         Club club = club1();
         Long clubId = club.getId();
 
-        given(inviteService.getInviteCode(any(Long.class), any(Long.class))).willReturn("650d2d91-a8cf-45e7-8a43-a0c798173ecb");
+        given(inviteService.getInviteCode(any(Long.class), any())).willReturn("650d2d91-a8cf-45e7-8a43-a0c798173ecb");
 
         // when
         ResultActions actions = mockMvc.perform(post("/api/v1/clubs/{clubId}/invite", clubId)

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.event.controller.dto.BookmarkedEventRequest;
 import com.spaceclub.event.domain.Event;
+import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
 import com.spaceclub.global.jwt.service.JwtManager;
 import com.spaceclub.user.UserTestFixture;
@@ -105,6 +106,9 @@ class UserControllerTest {
     @MockBean
     private JwtManager jwtManager;
 
+    @MockBean
+    private UserArgumentResolver userArgumentResolver;
+
     @Test
     @WithMockUser
     void 유저의_모든_이벤트_조회에_성공한다() throws Exception {
@@ -112,8 +116,8 @@ class UserControllerTest {
         List<Event> events = List.of(event1(), showEvent(), clubEvent());
         Page<Event> eventPages = new PageImpl<>(events);
 
-        given(userService.findAllEventPages(any(Long.class), any(Pageable.class))).willReturn(eventPages);
-        given(userService.findEventStatus(any(Long.class), any(Event.class))).willReturn("CONFIRMED");
+        given(userService.findAllEventPages(any(), any(Pageable.class))).willReturn(eventPages);
+        given(userService.findEventStatus(any(), any(Event.class))).willReturn("CONFIRMED");
 
         // when, then
         mvc.perform(get("/api/v1/users/events")
@@ -383,8 +387,7 @@ class UserControllerTest {
     @WithMockUser
     void 유저의_모든_클럽_조회에_성공한다() throws Exception {
         // given
-        given(jwtManager.verifyUserId(any())).willReturn(1L);
-        given(userService.getClubs(1L)).willReturn(List.of(club1(), club2()));
+        given(userService.getClubs(any())).willReturn(List.of(club1(), club2()));
 
         // when
         ResultActions actions = mvc.perform(get("/api/v1/users/clubs")
@@ -418,7 +421,7 @@ class UserControllerTest {
 
         Long userId = 1L;
         given(jwtManager.verifyUserId(any())).willReturn(userId);
-        given(userService.findAllBookmarkedEventPages(any(Long.class), any(Pageable.class))).willReturn(eventPages);
+        given(userService.findAllBookmarkedEventPages(any(), any(Pageable.class))).willReturn(eventPages);
 
         // when, then
         mvc.perform(get("/api/v1/users/bookmarked-events")


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-340](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-340)
  <br>

### 🖥️ 작업 내용
- `@Authenticated` 어노테이션과 JwtUser를 같이 컨트롤러에 받으면 user의 claim 값을 받을 수 있는 기능 설정
- 그에 따른 테스트 변경

<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
마지막 두 커밋만 보면 됩니다

앞으로 컨트롤러에서 인증 사항 관련하여 `@Authenticated` 와 JwtUser 객체를 파라미터로 user claim 값들을 받을 수 있어요

현지님, 성원님 해당 pr 머지 후 바꿔야 할 사항:
현재 WebConfig 파일안에 어떤 endpoint에 대해서 interceptor를 태울지 안태울지 변경할지 설정할 수 있어요
WebConfig 파일에 각자 맡은 api 중에 인증, 인가가 필요없는 endpoint (Access token 안 받는 controller endpoint)를 excludePatterns에 추가해줘야 해요. 안그러면 interceptor를 타버려서 프론트에서 api 요청시 문제가 생길거에요

[SKRB-340]: https://space-club.atlassian.net/browse/SKRB-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ