### PR TITLE
[SRKB-376] feat: 인증 및 인가 interceptor 분리

### DIFF
--- a/src/main/java/com/spaceclub/global/UserArgumentResolver.java
+++ b/src/main/java/com/spaceclub/global/UserArgumentResolver.java
@@ -38,11 +38,14 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String authorizationHeader = Objects.requireNonNull(request)
+                .getHeader(AUTHORIZATION);
 
-        String accessToken = Objects.requireNonNull(request)
-                .getHeader(AUTHORIZATION)
-                .replace(TOKEN_PREFIX, "");
+        if (authorizationHeader == null) {
+            return new JwtUser(null, null);
+        }
 
+        String accessToken = authorizationHeader.replace(TOKEN_PREFIX, "");
         Claims claims = jwtManager.getClaims(accessToken);
 
         return new JwtUser(claims.getId(), claims.getUsername());

--- a/src/main/java/com/spaceclub/global/UserArgumentResolver.java
+++ b/src/main/java/com/spaceclub/global/UserArgumentResolver.java
@@ -36,19 +36,20 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter,
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
+                                  WebDataBinderFactory binderFactory
+    ) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         String authorizationHeader = Objects.requireNonNull(request)
                 .getHeader(AUTHORIZATION);
 
         if (authorizationHeader == null) {
-            return new JwtUser(null, null);
+            return JwtUser.empty();
         }
 
         String accessToken = authorizationHeader.replace(TOKEN_PREFIX, "");
         Claims claims = jwtManager.getClaims(accessToken);
 
-        return new JwtUser(claims.getId(), claims.getUsername());
+        return JwtUser.from(claims);
     }
 
 }

--- a/src/main/java/com/spaceclub/global/config/WebConfig.java
+++ b/src/main/java/com/spaceclub/global/config/WebConfig.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtAuthorizationInterceptor jwtAccessTokenInterceptor;
+    private final JwtAuthorizationInterceptor jwtAuthorizationInterceptor;
     private final UserArgumentResolver userArgumentResolver;
 
     @Profile("develop")
@@ -29,34 +29,33 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("OPTIONS", "GET", "POST", "PATCH", "DELETE")
                 .allowCredentials(true)
                 .exposedHeaders("Location")
-                .maxAge(1800); // 1800초, 30분으로 설정
+                .maxAge(1800);
     }
 
+    /**
+     * 인증 및 인가
+     * 인가 처리가 optional or 필요 없는 endpoint는 인증만 처리 (AuthenticationInterceptor)
+     * 인가 처리가 필수 적인 endpoint는 인가 처리 (JwtAuthorizationInterceptor)
+     */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthenticationInterceptor(jwtAccessTokenInterceptor))
+        registry.addInterceptor(new AuthenticationInterceptor(jwtAuthorizationInterceptor))
                 .addPathPatterns(
-                        "/api/v1/events/{eventId}",
+                        "/api/v1/users/oauth**",
                         "/api/v1/users*",
-                        "/api/v1/clubs/invite/{code}",
-                        "/api/v1/events**",
-                        "/api/v1/users*",
-                        "/api/v1/users/oauths",
-                        "/api/v1/clubs/invite/{code}"
-                        ) // 인가
+                        "/api/v1/clubs/invite**",
+                        "/api/v1/events**"
+                        )
                 .order(1);
 
-        registry.addInterceptor(jwtAccessTokenInterceptor)
+        registry.addInterceptor(jwtAuthorizationInterceptor)
                 .order(2)
                 .addPathPatterns("/api/v1/**")
                 .excludePathPatterns(
-                        "/api/v1/events/{eventId}",
+                        "/api/v1/users/oauth**",
                         "/api/v1/users*",
-                        "/api/v1/clubs/invite/{code}",
-                        "/api/v1/events**",
-                        "/api/v1/users*",
-                        "/api/v1/users/oauths",
-                        "/api/v1/clubs/invite/{code}"
+                        "/api/v1/clubs/invite**",
+                        "/api/v1/events**"
                 );
     }
 

--- a/src/main/java/com/spaceclub/global/config/WebConfig.java
+++ b/src/main/java/com/spaceclub/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.spaceclub.global.config;
 
 import com.spaceclub.global.UserArgumentResolver;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
 import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -33,12 +34,30 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthenticationInterceptor(jwtAccessTokenInterceptor))
+                .addPathPatterns(
+                        "/api/v1/events/{eventId}",
+                        "/api/v1/users*",
+                        "/api/v1/clubs/invite/{code}",
+                        "/api/v1/events**",
+                        "/api/v1/users*",
+                        "/api/v1/users/oauths",
+                        "/api/v1/clubs/invite/{code}"
+                        ) // 인가
+                .order(1);
+
         registry.addInterceptor(jwtAccessTokenInterceptor)
-                .addPathPatterns("**/api/v1/**")
+                .order(2)
+                .addPathPatterns("/api/v1/**")
                 .excludePathPatterns(
-                        "**/api/v1/users",
-                        "**/api/v1/users/oauths",
-                        "**/api/v1/clubs/invite/"); //  path 추후 변경 예정
+                        "/api/v1/events/{eventId}",
+                        "/api/v1/users*",
+                        "/api/v1/clubs/invite/{code}",
+                        "/api/v1/events**",
+                        "/api/v1/users*",
+                        "/api/v1/users/oauths",
+                        "/api/v1/clubs/invite/{code}"
+                );
     }
 
     @Override

--- a/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
@@ -3,12 +3,10 @@ package com.spaceclub.global.interceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
-@Component
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
 

--- a/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,27 @@
+package com.spaceclub.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final JwtAuthorizationInterceptor jwtAuthorizationInterceptor;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+        if (authorizationHeader == null) {
+            return true;
+        }
+
+        return jwtAuthorizationInterceptor.preHandle(request, response, handler);
+    }
+
+}

--- a/src/main/java/com/spaceclub/global/jwt/vo/JwtUser.java
+++ b/src/main/java/com/spaceclub/global/jwt/vo/JwtUser.java
@@ -4,6 +4,10 @@ import com.spaceclub.global.jwt.Claims;
 
 public record JwtUser(Long id, String username) {
 
+    public static JwtUser empty() {
+        return new JwtUser(null, null);
+    }
+
     public static JwtUser from(Claims claims) {
         Long userId = claims.getId();
         String username = claims.getUsername();


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SRKB-376](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-376)
  <br>

### 🖥️ 작업 내용
- 인증과 인가 분리
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
- 인증과 인가를 분리했어요
현재 저희 서비스는 jwt 토큰에 role이 없어 인증만 담당합니다.
그런데 몇 컨트롤러에서 Authorization header 여부로 인증 처리를다르게 해야하는 경우가 있었어요
그래서 Authorization header 가 null이면 interceptor 통과 해서 controller로 바로 가게 처리했고,
null이 아니면 jwtAuthorization Interceptor를 호출해서 인가 처리를 하게 했어요

그래서 인가 필터에 등록한 것들은 Authorization이 없어도되고 있어도 되는 endpoint들이에요.
있으면 jwt 검증 처리가 이루어 집니다.
반면, jwt가 없다면 컨트롤러 로직이 수행됩니다.

---
저희 서비스는 인가 처리를 서비스 단에서 하네요
그래서 사실 그냥 access token 없으면 통과시켜도 상관없을것 같아요