### PR TITLE
[SKRB-374] feat: 클럽 로고 이미지 저장시 URL prefix 제거

### DIFF
--- a/src/main/java/com/spaceclub/club/controller/ClubController.java
+++ b/src/main/java/com/spaceclub/club/controller/ClubController.java
@@ -40,7 +40,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubGetResponse.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubGetResponse.java
@@ -3,6 +3,8 @@ package com.spaceclub.club.controller.dto;
 import com.spaceclub.club.domain.Club;
 import lombok.Builder;
 
+import static com.spaceclub.club.service.ClubService.CLUB_LOGO_S3_URL;
+
 public record ClubGetResponse(
         String name,
         String logoImageUrl,
@@ -18,10 +20,10 @@ public record ClubGetResponse(
     public static ClubGetResponse from(Club club) {
         return ClubGetResponse.builder()
                 .name(club.getName())
-                .logoImageUrl(club.getLogoImageUrl())
+                .logoImageUrl(CLUB_LOGO_S3_URL + club.getLogoImageUrl())
                 .info(club.getInfo())
                 .memberCount(club.getClubUser().size())
-                .coverImageUrl(club.getCoverImageUrl())
+                .coverImageUrl(CLUB_LOGO_S3_URL + club.getCoverImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/spaceclub/club/service/ClubService.java
+++ b/src/main/java/com/spaceclub/club/service/ClubService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 
 import static com.spaceclub.club.domain.ClubUserRole.MEMBER;
@@ -53,14 +52,14 @@ public class ClubService {
 
     private final S3ImageUploader imageUploader;
 
-    private static final String CLUB_LOGO_S3_URL = "https://space-club-image-bucket.s3.ap-northeast-2.amazonaws.com/club-logo/";
+    public static final String CLUB_LOGO_S3_URL = "https://space-club-image-bucket.s3.ap-northeast-2.amazonaws.com/club-logo/";
 
     public Club createClub(Club club, Long userId, MultipartFile logoImage) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException(USER_NOT_FOUND.toString()));
 
         if (logoImage != null) {
-            String logoImageUrl = CLUB_LOGO_S3_URL + imageUploader.uploadClubLogoImage(logoImage);
+            String logoImageUrl = imageUploader.uploadClubLogoImage(logoImage);
             club = club.addLogoImageUrl(logoImageUrl);
         }
 


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-374](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-374)
  <br>

### 🖥️ 작업 내용
- == 제목
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
- 기존에 완전한 URL 형태로 이미지 URL이 저장되어있는 클럽 정보들은 앞의 prefix 부분 없애고 사진 이름만 남게끔 수정할게요


[SKRB-374]: https://space-club.atlassian.net/browse/SKRB-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ