### PR TITLE
[SKRB-397] feat: 인증 및 인가 인터셉터 분리 및 경로 재설정

### DIFF
--- a/src/main/java/com/spaceclub/global/config/WebConfig.java
+++ b/src/main/java/com/spaceclub/global/config/WebConfig.java
@@ -2,7 +2,7 @@ package com.spaceclub.global.config;
 
 import com.spaceclub.global.UserArgumentResolver;
 import com.spaceclub.global.interceptor.AuthenticationInterceptor;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -13,13 +13,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
-@Profile(value = {"develop", "local"})
+@Profile({"develop", "local"})
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtAuthorizationInterceptor jwtAuthorizationInterceptor;
     private final UserArgumentResolver userArgumentResolver;
+    private final AuthenticationInterceptor authenticationInterceptor;
+    private final AuthorizationInterceptor authorizationInterceptor;
 
     @Profile("develop")
     @Override
@@ -32,32 +33,17 @@ public class WebConfig implements WebMvcConfigurer {
                 .maxAge(1800);
     }
 
-    /**
-     * 인증 및 인가
-     * 인가 처리가 optional or 필요 없는 endpoint는 인증만 처리 (AuthenticationInterceptor)
-     * 인가 처리가 필수 적인 endpoint는 인가 처리 (JwtAuthorizationInterceptor)
-     */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthenticationInterceptor(jwtAuthorizationInterceptor))
-                .addPathPatterns(
-                        "/api/v1/users/oauth**",
-                        "/api/v1/users*",
-                        "/api/v1/clubs/invite**",
-                        "/api/v1/events**",
-                        "/api/v1/events/**"
-                        )
+        registry.addInterceptor(authenticationInterceptor)
+                .addPathPatterns("/api/v1/**")
                 .order(1);
 
-        registry.addInterceptor(jwtAuthorizationInterceptor)
+        registry.addInterceptor(authorizationInterceptor)
                 .order(2)
                 .addPathPatterns("/api/v1/**")
-                .excludePathPatterns(
-                        "/api/v1/users/oauth**",
-                        "/api/v1/users*",
-                        "/api/v1/clubs/invite**",
-                        "/api/v1/events**",
-                        "/api/v1/events/**"
+                .excludePathPatterns( // 반드시 인가 처리가 필수가 아닌 path 추가
+                        "/api/v1/users/oauth**"
                 );
     }
 

--- a/src/main/java/com/spaceclub/global/config/WebConfig.java
+++ b/src/main/java/com/spaceclub/global/config/WebConfig.java
@@ -40,11 +40,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1);
 
         registry.addInterceptor(authorizationInterceptor)
-                .order(2)
                 .addPathPatterns("/api/v1/**")
-                .excludePathPatterns( // 반드시 인가 처리가 필수가 아닌 path 추가
-                        "/api/v1/users/oauth**"
-                );
+                .order(2);
     }
 
     @Override

--- a/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
@@ -3,23 +3,29 @@ package com.spaceclub.global.interceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
+@Component
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
-    private final JwtAuthorizationInterceptor jwtAuthorizationInterceptor;
+    private static final String REFRESH_TOKEN = "RefreshToken";
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String authorizationHeader = request.getHeader(AUTHORIZATION);
-        if (authorizationHeader == null) {
+        String refreshTokenHeader = request.getHeader(REFRESH_TOKEN);
+
+        if (authorizationHeader == null && refreshTokenHeader == null) {
             return true;
         }
 
-        return jwtAuthorizationInterceptor.preHandle(request, response, handler);
+        return jwtAuthenticationProvider.authenticate(authorizationHeader, refreshTokenHeader, response);
     }
 
 }

--- a/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/spaceclub/global/interceptor/AuthenticationInterceptor.java
@@ -21,7 +21,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         String authorizationHeader = request.getHeader(AUTHORIZATION);
         String refreshTokenHeader = request.getHeader(REFRESH_TOKEN);
 
-        if (authorizationHeader == null && refreshTokenHeader == null) {
+        boolean isTokenDoesNotExists = authorizationHeader == null && refreshTokenHeader == null;
+        if (isTokenDoesNotExists) {
             return true;
         }
 

--- a/src/main/java/com/spaceclub/global/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/spaceclub/global/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,52 @@
+package com.spaceclub.global.interceptor;
+
+import com.spaceclub.global.jwt.Claims;
+import com.spaceclub.global.jwt.JwtManager;
+import com.spaceclub.user.service.AccountService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableSet;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final Map<String, HttpMethod> PATH_TO_EXCLUDE = Map.of(
+            "/api/v1/users", POST,
+            "/api/v1/clubs/invites/", GET,
+            "/api/v1/events", GET,
+            "/api/v1/events/searches", GET
+    );
+
+    private final AccountService accountService;
+    private final JwtManager jwtManager;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        for (Map.Entry<String, HttpMethod> entry : unmodifiableSet(PATH_TO_EXCLUDE.entrySet())) {
+            boolean matchesPathAndMethod = request.getRequestURI().contains(entry.getKey()) &&
+                    request.getMethod().equals(entry.getValue().name());
+
+            if (matchesPathAndMethod) {
+                return true;
+            }
+        }
+
+        String header = request.getHeader(AUTHORIZATION).replace(TOKEN_PREFIX, "");
+        Claims claims = jwtManager.getClaims(header);
+
+        return accountService.isAuthenticatedUser(claims.getId(), claims.getUsername());
+    }
+
+}

--- a/src/main/java/com/spaceclub/global/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/spaceclub/global/interceptor/AuthorizationInterceptor.java
@@ -22,14 +22,17 @@ import static org.springframework.http.HttpMethod.POST;
 public class AuthorizationInterceptor implements HandlerInterceptor {
 
     private static final String TOKEN_PREFIX = "Bearer ";
+
     private static final Map<String, HttpMethod> PATH_TO_EXCLUDE = Map.of(
             "/api/v1/users", POST,
             "/api/v1/clubs/invites/", GET,
             "/api/v1/events", GET,
-            "/api/v1/events/searches", GET
+            "/api/v1/events/searches", GET,
+            "/api/v1/users/oauth", POST
     );
 
     private final AccountService accountService;
+
     private final JwtManager jwtManager;
 
     @Override

--- a/src/main/java/com/spaceclub/global/interceptor/JwtAuthenticationProvider.java
+++ b/src/main/java/com/spaceclub/global/interceptor/JwtAuthenticationProvider.java
@@ -23,6 +23,7 @@ public class JwtAuthenticationProvider {
     private static final String TOKEN_PREFIX = "Bearer ";
 
     private final JwtManager jwtManager;
+
     private final Jwt jwt;
 
     public boolean authenticate(String authorizationHeader, String refreshTokenHeader, HttpServletResponse response) {

--- a/src/main/java/com/spaceclub/global/interceptor/JwtAuthenticationProvider.java
+++ b/src/main/java/com/spaceclub/global/interceptor/JwtAuthenticationProvider.java
@@ -1,39 +1,34 @@
 package com.spaceclub.global.interceptor;
 
 import com.spaceclub.global.exception.AccessTokenException;
+import com.spaceclub.global.exception.RefreshTokenException;
 import com.spaceclub.global.exception.TokenException;
 import com.spaceclub.global.jwt.Jwt;
 import com.spaceclub.global.jwt.JwtManager;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 import static com.spaceclub.global.exception.GlobalExceptionCode.INVALID_ACCESS_TOKEN;
+import static com.spaceclub.global.exception.GlobalExceptionCode.INVALID_REFRESH_TOKEN;
 import static com.spaceclub.global.exception.GlobalExceptionCode.INVALID_TOKEN_FORMAT;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtAuthorizationInterceptor implements HandlerInterceptor {
+public class JwtAuthenticationProvider {
 
     private static final String TOKEN_PREFIX = "Bearer ";
-    private static final String REFRESH_TOKEN = "RefreshToken";
 
     private final JwtManager jwtManager;
     private final Jwt jwt;
 
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String authorizationHeader = request.getHeader(AUTHORIZATION);
+    public boolean authenticate(String authorizationHeader, String refreshTokenHeader, HttpServletResponse response) {
         validate(authorizationHeader);
 
         String accessToken = authorizationHeader.replace(TOKEN_PREFIX, "");
-        String refreshTokenHeader = request.getHeader(REFRESH_TOKEN);
 
         if (refreshTokenHeader != null) {
             validate(refreshTokenHeader);
@@ -43,20 +38,19 @@ public class JwtAuthorizationInterceptor implements HandlerInterceptor {
             String username = jwt.getClaims(accessToken).getUsername();
 
             if (jwtManager.isValidRefreshToken(refreshToken, userId)) {
-                log.info("access token interceptor preHandle(), refresh token is valid");
+                log.info("리프레시 토큰이 유효합니다. 새로운 access token을 발급합니다.");
                 response.addHeader(AUTHORIZATION, jwtManager.createAccessToken(userId, username));
 
                 return true;
             }
+            throw new RefreshTokenException(INVALID_REFRESH_TOKEN);
         }
 
         if (jwt.isValidFormat(accessToken)) {
-            log.info("JWT interceptor preHandle(), access token이 유효합니다.");
+            log.info("access token이 유효해 인증에 성공했습니다.");
 
             return true;
         }
-
-        log.info("JWT interceptor preHandle(), 리프레시 토큰이 존재하지 않습니다.");
         throw new AccessTokenException(INVALID_ACCESS_TOKEN);
     }
 
@@ -65,19 +59,6 @@ public class JwtAuthorizationInterceptor implements HandlerInterceptor {
 
         if (isWrongFormat) {
             throw new TokenException(INVALID_TOKEN_FORMAT);
-        }
-    }
-
-    @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
-        log.info("access token interceptor postHandle()");
-    }
-
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
-        if (ex != null) {
-            log.info("access token interceptor afterCompletion(), exception", ex);
-            throw ex;
         }
     }
 

--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -24,8 +24,6 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class User {
 
-    private static final String USER_PROFILE_S3_URL = "https://space-club-image-bucket.s3.ap-northeast-2.amazonaws.com/user-profile-image/";
-
     @Id
     @Getter
     @GeneratedValue(strategy = IDENTITY)
@@ -53,6 +51,7 @@ public class User {
     private String refreshToken;
 
     @Lob
+    @Getter
     private String profileImageUrl;
 
     private User(
@@ -106,10 +105,6 @@ public class User {
         Assert.hasText(phoneNumber, "전화번호는 필수입니다.");
 
         return new RequiredInfo(nickname, new PhoneNumber(phoneNumber));
-    }
-
-    public String getName() {
-        return requiredInfo.getName();
     }
 
     public boolean isNewMember() {
@@ -168,10 +163,8 @@ public class User {
         );
     }
 
-    public String getProfileImageUrl() {
-        if (this.profileImageUrl == null) return null;
-
-        return USER_PROFILE_S3_URL + profileImageUrl;
+    public boolean isValid(String username) {
+        return this.getUsername().equals(username);
     }
 
 }

--- a/src/main/java/com/spaceclub/user/service/AccountService.java
+++ b/src/main/java/com/spaceclub/user/service/AccountService.java
@@ -1,9 +1,9 @@
 package com.spaceclub.user.service;
 
-import com.spaceclub.global.jwt.JwtManager;
 import com.spaceclub.global.config.oauth.KakaoOauthInfoSender;
 import com.spaceclub.global.config.oauth.vo.KakaoTokenInfo;
 import com.spaceclub.global.config.oauth.vo.KakaoUserInfo;
+import com.spaceclub.global.jwt.JwtManager;
 import com.spaceclub.user.domain.Email;
 import com.spaceclub.user.domain.Provider;
 import com.spaceclub.user.domain.User;
@@ -81,5 +81,13 @@ public class AccountService {
         return UserLoginInfo.from(user.getId(), accessToken, refreshToken);
     }
 
+    public boolean isAuthenticatedUser(Long userId, String username) {
+        User user = getUser(userId);
+
+        if (!user.isValid(username)) {
+            throw new IllegalStateException(USER_NOT_FOUND.toString());
+        }
+        return true;
+    }
 
 }

--- a/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubControllerTest.java
@@ -7,7 +7,8 @@ import com.spaceclub.club.controller.dto.ClubUpdateRequest;
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.club.service.ClubService;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +60,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = ClubController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/club/controller/ClubEventControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubEventControllerTest.java
@@ -6,7 +6,8 @@ import com.spaceclub.club.service.ClubEventService;
 import com.spaceclub.event.service.vo.EventGetInfo;
 import com.spaceclub.event.service.vo.SchedulesGetInfo;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +56,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = ClubEventController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/club/controller/ClubNoticeControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubNoticeControllerTest.java
@@ -7,7 +7,8 @@ import com.spaceclub.club.controller.dto.ClubNoticeUpdateRequest;
 import com.spaceclub.club.service.ClubNoticeService;
 import com.spaceclub.club.service.vo.ClubNoticeUpdate;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +56,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = ClubNoticeController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/club/controller/ClubUserControllerTest.java
+++ b/src/test/java/com/spaceclub/club/controller/ClubUserControllerTest.java
@@ -3,12 +3,13 @@ package com.spaceclub.club.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.controller.dto.ClubUserUpdateRequest;
-import com.spaceclub.club.service.vo.MemberGetInfo;
 import com.spaceclub.club.domain.ClubUserRole;
 import com.spaceclub.club.service.ClubMemberManagerService;
 import com.spaceclub.club.service.vo.ClubUserUpdate;
+import com.spaceclub.club.service.vo.MemberGetInfo;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +59,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         value = ClubUserController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs
@@ -114,14 +116,14 @@ class ClubUserControllerTest {
 
         MemberGetInfo memberGetInfo1 = MemberGetInfo.builder()
                 .id(1L)
-                .name(user1().getName())
+                .name(user1().getUsername())
                 .profileImageUrl(user1().getProfileImageUrl())
                 .role(ClubUserRole.MANAGER)
                 .build();
 
         MemberGetInfo memberGetInfo2 = MemberGetInfo.builder()
                 .id(2L)
-                .name(user2().getName())
+                .name(user2().getUsername())
                 .profileImageUrl(user2().getProfileImageUrl())
                 .role(ClubUserRole.MANAGER)
                 .build();

--- a/src/test/java/com/spaceclub/club/controller/dto/MemberGetInfoTest.java
+++ b/src/test/java/com/spaceclub/club/controller/dto/MemberGetInfoTest.java
@@ -78,28 +78,28 @@ class MemberGetInfoTest {
         // given
         MemberGetInfo clubUserOrder1 = MemberGetInfo.builder()
                 .id(1L)
-                .name(user1().getName())
+                .name(user1().getUsername())
                 .profileImageUrl(user1().getProfileImageUrl())
                 .role(ClubUserRole.MANAGER)
                 .build();
 
         MemberGetInfo clubUserOrder2 = MemberGetInfo.builder()
                 .id(2L)
-                .name(user2().getName())
+                .name(user2().getUsername())
                 .profileImageUrl(user2().getProfileImageUrl())
                 .role(ClubUserRole.MEMBER)
                 .build();
 
         MemberGetInfo clubUserOrder3 = MemberGetInfo.builder()
                 .id(3L)
-                .name(user3().getName())
+                .name(user3().getUsername())
                 .profileImageUrl(user3().getProfileImageUrl())
                 .role(ClubUserRole.MANAGER)
                 .build();
 
         MemberGetInfo clubUserOrder4 = MemberGetInfo.builder()
                 .id(4L)
-                .name(user4().getName())
+                .name(user4().getUsername())
                 .profileImageUrl(user4().getProfileImageUrl())
                 .role(ClubUserRole.MEMBER)
                 .build();

--- a/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
@@ -16,7 +16,8 @@ import com.spaceclub.event.service.EventService;
 import com.spaceclub.event.service.EventValidator;
 import com.spaceclub.event.service.vo.EventCreateInfo;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,7 +90,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = EventController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/event/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/ParticipationControllerTest.java
@@ -7,7 +7,8 @@ import com.spaceclub.event.service.ParticipationService;
 import com.spaceclub.event.service.vo.EventParticipationCreateInfo;
 import com.spaceclub.form.FormTestFixture;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +52,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = ParticipationController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/form/controller/FormControllerTest.java
+++ b/src/test/java/com/spaceclub/form/controller/FormControllerTest.java
@@ -10,7 +10,8 @@ import com.spaceclub.form.service.FormService;
 import com.spaceclub.form.service.vo.FormCreateInfo;
 import com.spaceclub.form.service.vo.FormGetInfo;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +56,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = FormController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/form/controller/SubmitControllerTest.java
+++ b/src/test/java/com/spaceclub/form/controller/SubmitControllerTest.java
@@ -10,7 +10,8 @@ import com.spaceclub.form.service.SubmitService;
 import com.spaceclub.form.service.vo.FormSubmitGetInfo;
 import com.spaceclub.form.service.vo.FormSubmitUpdateInfo;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +60,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = SubmitController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/invite/controller/InviteControllerTest.java
+++ b/src/test/java/com/spaceclub/invite/controller/InviteControllerTest.java
@@ -3,7 +3,8 @@ package com.spaceclub.invite.controller;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import com.spaceclub.invite.service.InviteService;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = InviteController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/invite/controller/InviteJoinControllerTest.java
+++ b/src/test/java/com/spaceclub/invite/controller/InviteJoinControllerTest.java
@@ -3,7 +3,8 @@ package com.spaceclub.invite.controller;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.service.ClubMemberManagerService;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import com.spaceclub.invite.service.InviteJoinService;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = InviteJoinController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/user/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/BookmarkControllerTest.java
@@ -6,7 +6,8 @@ import com.spaceclub.event.controller.dto.BookmarkedEventRequest;
 import com.spaceclub.event.domain.Event;
 import com.spaceclub.event.service.EventService;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import com.spaceclub.user.service.BookmarkService;
 import com.spaceclub.user.service.vo.UserBookmarkInfo;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -59,7 +60,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = BookmarkController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/user/controller/ContentControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/ContentControllerTest.java
@@ -6,7 +6,8 @@ import com.spaceclub.club.service.vo.ClubInfo;
 import com.spaceclub.event.service.ParticipationProvider;
 import com.spaceclub.event.service.vo.EventPageInfo;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +54,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = ContentController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/user/controller/LoginControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/LoginControllerTest.java
@@ -3,7 +3,8 @@ package com.spaceclub.user.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import com.spaceclub.user.controller.dto.UserRequiredInfoRequest;
 import com.spaceclub.user.service.AccountService;
 import com.spaceclub.user.service.vo.UserLoginInfo;
@@ -47,7 +48,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = LoginController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/UserControllerTest.java
@@ -3,7 +3,8 @@ package com.spaceclub.user.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.global.UserArgumentResolver;
-import com.spaceclub.global.interceptor.JwtAuthorizationInterceptor;
+import com.spaceclub.global.interceptor.AuthenticationInterceptor;
+import com.spaceclub.global.interceptor.AuthorizationInterceptor;
 import com.spaceclub.user.controller.dto.UserProfileUpdateRequest;
 import com.spaceclub.user.service.UserService;
 import com.spaceclub.user.service.vo.UserProfile;
@@ -55,7 +56,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(value = UserController.class,
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
-                        JwtAuthorizationInterceptor.class,
+                        AuthorizationInterceptor.class,
+                        AuthenticationInterceptor.class
                 })
         })
 @AutoConfigureRestDocs

--- a/src/test/java/com/spaceclub/user/domain/UserTest.java
+++ b/src/test/java/com/spaceclub/user/domain/UserTest.java
@@ -1,11 +1,15 @@
 package com.spaceclub.user.domain;
 
 import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import com.spaceclub.user.UserTestFixture;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 
 import static com.spaceclub.user.domain.Provider.KAKAO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class UserTest {
@@ -25,6 +29,82 @@ class UserTest {
 
         // then
         assertThat(isNewMember).isTrue();
+    }
+
+    @Test
+    void 유저의_프로필_이미지를_null로_변경에_실패한다() {
+        // given
+        User user = UserTestFixture.user1();
+
+        // when, then
+        assertThatThrownBy(() -> user.changeProfileImageUrl(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 유저의_프로필_이미지_변경에_성공한다() {
+        // given
+        User user = UserTestFixture.user1();
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> user.changeProfileImageUrl("imageurl.com"));
+    }
+
+    @Test
+    void 유저의_리프레시토큰_변경에_성공한다() {
+        // given
+        User user = UserTestFixture.user1();
+
+        // when
+        final String newRefreshToken = "newRefreshToken";
+        User refreshTokenUpdatedUser = user.updateRefreshToken(newRefreshToken);
+
+        // then
+        assertThat(refreshTokenUpdatedUser.getRefreshToken()).isEqualTo(newRefreshToken);
+    }
+
+    @Test
+    void 유저의_필수정보_변경에_성공한다() {
+        // given
+        User user = UserTestFixture.user1();
+
+        // when
+        final String usernameToUpdate = "업데이트된 멤버명";
+        final String phoneNumberToUpdate = "01012346789";
+        User updatedUser = user.updateRequiredInfo(usernameToUpdate, phoneNumberToUpdate);
+
+        // then
+        assertAll(
+                () -> assertThat(updatedUser.getUsername()).isEqualTo(usernameToUpdate),
+                () -> assertThat(updatedUser.getPhoneNumber()).isEqualTo(phoneNumberToUpdate)
+        );
+    }
+
+    @Test
+    void 유저의_닉네임이_입력과_같다면_유저_검증에_성공한다() {
+        // given
+        final User user = UserTestFixture.user1();
+        final String username = user.getUsername();
+
+        // when
+        boolean isValid = user.isValid(username);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void 유저의_닉네임이_입력과_다르다면_유저_검증에_실패한다() {
+        // given
+        final User user = UserTestFixture.user1();
+        final String username = "다른 닉네임";
+
+        // when
+        boolean isValid = user.isValid(username);
+
+        // then
+        assertThat(isValid).isFalse();
     }
 
 }


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-397](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?assignee=5fa0f9c5248fc30078abb600&selectedIssue=SKRB-397)
  <br>

### 🖥️ 작업 내용
- 인증 및 인가 인터셉터 분리
- 인가 인터셉터에서 같은 path이지만 특정 메서드는 인가 하지 않도록 분리
- User 엔티티 단위 테스트 작성
- User 엔티티의 `getName()`, `getUsername()`  메서드 중복 제거
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
- 머지 커밋 예정입니다


[SKRB-397]: https://space-club.atlassian.net/browse/SKRB-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ