### PR TITLE
[SKRB-395] feat: 유저의 상태가 INACTIVE일 경우 로그인 시 탈퇴 해제 기능 구현

### DIFF
--- a/src/main/java/com/spaceclub/user/domain/User.java
+++ b/src/main/java/com/spaceclub/user/domain/User.java
@@ -187,4 +187,21 @@ public class User {
         );
     }
 
+    public boolean isInactive() {
+        return this.status.equals(INACTIVE);
+    }
+
+    public User changeStatusToRegistered() {
+        return new User(
+                this.id,
+                this.requiredInfo,
+                REGISTERED,
+                this.oauthUserName,
+                this.provider,
+                this.email,
+                this.refreshToken,
+                this.profileImageUrl
+        );
+    }
+
 }

--- a/src/main/java/com/spaceclub/user/service/AccountService.java
+++ b/src/main/java/com/spaceclub/user/service/AccountService.java
@@ -38,6 +38,8 @@ public class AccountService {
         String accessToken = jwtManager.createAccessToken(kakaoUser.getId(), kakaoUser.getUsername());
         String refreshToken = jwtManager.createRefreshToken(kakaoUser.getId());
 
+        checkWhenUserStatusIsInactive(kakaoUser);
+
         return UserLoginInfo.from(kakaoUser.getId(), accessToken, refreshToken);
     }
 
@@ -51,6 +53,13 @@ public class AccountService {
 
         return userRepository.findByEmailAndOauthUserName(email, oauthUsername)
                 .orElseGet(() -> userRepository.save(userInfo.toUser()));
+    }
+
+    private void checkWhenUserStatusIsInactive(User kakaoUser) {
+        if (kakaoUser.isInactive()){
+            User user = kakaoUser.changeStatusToRegistered();
+            userRepository.save(user);
+        }
     }
 
     public void logout(Long userId) {

--- a/src/test/java/com/spaceclub/user/UserTestFixture.java
+++ b/src/test/java/com/spaceclub/user/UserTestFixture.java
@@ -3,6 +3,7 @@ package com.spaceclub.user;
 import com.spaceclub.user.domain.Provider;
 import com.spaceclub.user.domain.User;
 
+import static com.spaceclub.user.domain.Status.NOT_REGISTERED;
 import static com.spaceclub.user.domain.Status.REGISTERED;
 
 public class UserTestFixture {
@@ -30,6 +31,20 @@ public class UserTestFixture {
                 .oauthId("1234")
                 .provider(Provider.KAKAO)
                 .email("abcd@naver.com")
+                .refreshToken("refreshToken")
+                .profileImageUrl("www.image.com")
+                .build();
+    }
+
+    public static User notRegisteredUser() {
+        return User.builder()
+                .id(3L)
+                .name(null)
+                .phoneNumber(null)
+                .status(NOT_REGISTERED)
+                .oauthId("1234")
+                .provider(Provider.KAKAO)
+                .email("abce@naver.com")
                 .refreshToken("refreshToken")
                 .profileImageUrl("www.image.com")
                 .build();

--- a/src/test/java/com/spaceclub/user/service/AccountServiceTest.java
+++ b/src/test/java/com/spaceclub/user/service/AccountServiceTest.java
@@ -1,0 +1,83 @@
+package com.spaceclub.user.service;
+
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
+import com.spaceclub.global.config.oauth.KakaoOauthInfoSender;
+import com.spaceclub.global.config.oauth.vo.KakaoTokenInfo;
+import com.spaceclub.global.config.oauth.vo.KakaoUserInfo;
+import com.spaceclub.global.jwt.JwtManager;
+import com.spaceclub.user.UserTestFixture;
+import com.spaceclub.user.domain.User;
+import com.spaceclub.user.repository.UserRepository;
+import com.spaceclub.user.service.vo.UserLoginInfo;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
+class AccountServiceTest {
+
+    @InjectMocks
+    AccountService accountService;
+
+    @Mock
+    JwtManager jwtManager;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    KakaoOauthInfoSender kakaoOauthInfoSender;
+
+    @Test
+    void 필수정보를_작성하지않은_신규유저이면_토큰을_빈값으로_반환에_성공한다() {
+        // given
+        KakaoTokenInfo kakaoTokenInfo = new KakaoTokenInfo("tokenType", "accessToken", 1, "refreshToken", 1);
+        KakaoUserInfo.KakaoAccount kakaoAccount = new KakaoUserInfo.KakaoAccount(true, true, "test@gmail.com");
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(1L, kakaoAccount);
+        User user = UserTestFixture.notRegisteredUser();
+
+        given(kakaoOauthInfoSender.getAccessTokenInfo(any())).willReturn(kakaoTokenInfo);
+        given(kakaoOauthInfoSender.getUserInfo(any())).willReturn(kakaoUserInfo);
+        given(userRepository.findByEmailAndOauthUserName(any(), any())).willReturn(Optional.of(user));
+
+        // when
+        UserLoginInfo actual = accountService.loginUser("code");
+        UserLoginInfo expected = new UserLoginInfo(3L, "", "");
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void 유저가_신규_유저가_아니라면_엑세스토큰과_리프레시토큰을_생성해_반환하는데_성공한다() {
+        // given
+        KakaoTokenInfo kakaoTokenInfo = new KakaoTokenInfo("tokenType", "accessToken", 1, "refreshToken", 1);
+        KakaoUserInfo.KakaoAccount kakaoAccount = new KakaoUserInfo.KakaoAccount(true, true, "test@gmail.com");
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(1L, kakaoAccount);
+        User user = UserTestFixture.user1().changeStatusToInactive();
+
+        given(kakaoOauthInfoSender.getAccessTokenInfo(any())).willReturn(kakaoTokenInfo);
+        given(kakaoOauthInfoSender.getUserInfo(any())).willReturn(kakaoUserInfo);
+        given(userRepository.findByEmailAndOauthUserName(any(), any())).willReturn(Optional.of(user));
+        given(jwtManager.createAccessToken(any(), any())).willReturn("accessToken");
+        given(jwtManager.createRefreshToken(any())).willReturn("refreshToken");
+
+        // when
+        UserLoginInfo actual = accountService.loginUser("code");
+        UserLoginInfo expected = new UserLoginInfo(1L, "accessToken", "refreshToken");
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-395](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?selectedIssue=SKRB-395)
  <br>

### 🖥️ 작업 내용
- 로그인 시 inactive 상태일 경우 탈퇴 해제 기능 구현 (registered 상태로 변경)

<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [ ] Postman QA 여부 -> 외부 api 사용이 있어 qa 테스트가 불가했습니다. 주말 안으로 프론트와 협의해 qa 예정입니다.

  <br>

### 📢 리뷰어 전달 사항
- 마지막 커밋만 보면 됩니다

[SKRB-395]: https://space-club.atlassian.net/browse/SKRB-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ