### PR TITLE
[SKRB-415] feat: 모든 행사 조회, 클럽 행사 조회 시 size default값 설정

### DIFF
--- a/src/main/java/com/spaceclub/club/controller/ClubEventController.java
+++ b/src/main/java/com/spaceclub/club/controller/ClubEventController.java
@@ -9,6 +9,7 @@ import com.spaceclub.global.jwt.vo.JwtUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,7 +26,7 @@ public class ClubEventController {
     private final ClubEventService clubEventService;
 
     @GetMapping("/{clubId}/events")
-    public ResponseEntity<PageResponse<ClubEventOverviewGetResponse, ClubEventOverviewGetInfo>> getClubEvents(@PathVariable Long clubId, Pageable pageable, @Authenticated JwtUser jwtUser) {
+    public ResponseEntity<PageResponse<ClubEventOverviewGetResponse, ClubEventOverviewGetInfo>> getClubEvents(@PathVariable Long clubId, @PageableDefault(size = 1000) Pageable pageable, @Authenticated JwtUser jwtUser) {
         Page<ClubEventOverviewGetInfo> events = clubEventService.getClubEvents(clubId, pageable, jwtUser.id());
 
         List<ClubEventOverviewGetResponse> clubEventOverviewGetResponse = events.getContent()

--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -16,6 +16,7 @@ import com.spaceclub.global.jwt.vo.JwtUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -62,7 +63,7 @@ public class EventController {
     }
 
     @GetMapping
-    public ResponseEntity<PageResponse<EventOverviewGetResponse, Event>> getAll(@RequestParam EventCategory category, @RequestParam(required = false) Boolean isEnded, Pageable pageable) {
+    public ResponseEntity<PageResponse<EventOverviewGetResponse, Event>> getAll(@RequestParam EventCategory category, @RequestParam(required = false) Boolean isEnded, @PageableDefault(size = 1000) Pageable pageable) {
         Page<Event> events = eventService.getAll(category, pageable);
 
         List<EventOverviewGetResponse> responses = events.getContent()


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-415](https://space-club.atlassian.net/browse/SKRB-415)
  <br>

### 🖥️ 작업 내용
- 모든 행사 조회, 클럽 일정 조회 시 size default값 설정
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항

모든 행사 조회, 클럽 행사 조회 시 page 데이터 말고 전체 데이터가 필요한 경우가 있는데 그를 위해 default size를 1000으로 지정해두었습니다.
쿼리 파라미터로 분기해서도 구현이 가능하지만 각 카테고리 별로 종료된 행사, 클럽 행사가 1000개 이상인 경우에는 오히려 행사 홈 배너 불러오기, 클럽 일정 조회하기 기능의 개선 혹은 분리가 필요한 시점이라는 생각이 들어서 size default를 설정하는 방식으로 진행했습니다.

[SKRB-415]: https://space-club.atlassian.net/browse/SKRB-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ