### PR TITLE
[SKRB-419] feat: 이메일 통한 알림 기능 fallback 전략 구현 - DB에 저장

### DIFF
--- a/src/main/java/com/spaceclub/global/mail/MailEvent.java
+++ b/src/main/java/com/spaceclub/global/mail/MailEvent.java
@@ -1,0 +1,5 @@
+package com.spaceclub.global.mail;
+
+public record MailEvent(MailInfo mailInfo) {
+
+}

--- a/src/main/java/com/spaceclub/global/mail/MailInfo.java
+++ b/src/main/java/com/spaceclub/global/mail/MailInfo.java
@@ -1,5 +1,7 @@
 package com.spaceclub.global.mail;
 
+import java.util.List;
+
 public record MailInfo(
         String[] address,
         String[] ccAddress,
@@ -8,4 +10,16 @@ public record MailInfo(
         String template
 ) {
 
+    public static MailInfo of(
+            List<String> address,
+            List<String> ccAddress,
+            String title,
+            String markdownFileName,
+            String template
+    ) {
+        String[] addressArray = address.toArray(new String[0]);
+        String[] ccAddressArray = ccAddress.toArray(new String[0]);
+
+        return new MailInfo(addressArray, ccAddressArray, title, markdownFileName, template);
+    }
 }

--- a/src/main/java/com/spaceclub/global/mail/MailService.java
+++ b/src/main/java/com/spaceclub/global/mail/MailService.java
@@ -1,5 +1,7 @@
 package com.spaceclub.global.mail;
 
+import com.spaceclub.global.mail.domain.MailTracker;
+import com.spaceclub.global.mail.repository.MailTrackerRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -9,13 +11,17 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 
 import static com.fasterxml.jackson.core.JsonEncoding.UTF8;
-import static com.spaceclub.global.mail.HtmlConverter.*;
+import static com.spaceclub.global.mail.HtmlConverter.markdownToHtml;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 @Slf4j
 @Service
@@ -24,15 +30,26 @@ public class MailService {
 
     private static final String MARKDOWN_FILE_EXTENSION = ".md";
 
+    private static final String DELIMITER = ",";
+
     private final JavaMailSender emailSender;
+
     private final SpringTemplateEngine templateEngine;
+
     private final MailProperties mailProperties;
 
+    private final MailTrackerRepository mailTrackerRepository;
+
     @Async
-    public void sendEmail(MailInfo mailInfo) {
+    @Transactional(propagation = REQUIRES_NEW)
+    @TransactionalEventListener
+    public void sendEmail(MailEvent mailEvent) {
         MimeMessage message = emailSender.createMimeMessage();
+        MailInfo mailInfo = mailEvent.mailInfo();
+
         Context context = createContext(mailInfo.markdownFileName());
         String html = templateEngine.process(mailInfo.template(), context);
+        boolean isSent = true;
 
         try{
             MimeMessageHelper helper = new MimeMessageHelper(message, true, UTF8.getJavaName());
@@ -43,14 +60,29 @@ public class MailService {
             helper.setText(html, true);
             helper.addInline("image1", new ClassPathResource(mailProperties.backgroundUrl()));
             helper.addInline("image2", new ClassPathResource(mailProperties.logoUrl()));
+
             emailSender.send(message);
         } catch (MessagingException e) {
             log.error("메일 전송 실패", e);
-            // db 쌓기
-            throw new RuntimeException(e);
+            isSent = false;
+
+        } finally {
+            String addresses = String.join(DELIMITER, mailInfo.address());
+            String ccAddresses = String.join(DELIMITER, mailInfo.ccAddress());
+
+            MailTracker mailHistory = MailTracker.builder()
+                    .addresses(addresses)
+                    .ccAddresses(ccAddresses)
+                    .title(mailInfo.title())
+                    .markdownFileName(mailInfo.markdownFileName())
+                    .template(mailInfo.template())
+                    .sentAt(LocalDateTime.now())
+                    .isSent(isSent)
+                    .build();
+
+            mailTrackerRepository.save(mailHistory);
         }
         log.info("메일 발송 완료!");
-        // db 쌓기
     }
 
     private Context createContext(String markdownFileName) {

--- a/src/main/java/com/spaceclub/global/mail/domain/MailTracker.java
+++ b/src/main/java/com/spaceclub/global/mail/domain/MailTracker.java
@@ -1,0 +1,61 @@
+package com.spaceclub.global.mail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor(access = PROTECTED)
+public class MailTracker {
+
+    @Id
+    @Getter
+    @Column(name = "mail_tracker_id")
+    @GeneratedValue(strategy = IDENTITY)
+    Long id;
+
+    String addresses;
+
+    String ccAddresses;
+
+    String title;
+
+    String markdownFileName;
+
+    String template;
+
+    LocalDateTime sentAt;
+
+    boolean isSent;
+
+    @Builder
+    private MailTracker(
+            String addresses,
+            String ccAddresses,
+            String title,
+            String markdownFileName,
+            String template,
+            LocalDateTime sentAt,
+            boolean isSent
+    ) {
+        this.addresses = addresses;
+        this.ccAddresses = ccAddresses;
+        this.title = title;
+        this.markdownFileName = markdownFileName;
+        this.template = template;
+        this.sentAt = sentAt;
+        this.isSent = isSent;
+    }
+
+}

--- a/src/main/java/com/spaceclub/global/mail/repository/MailTrackerRepository.java
+++ b/src/main/java/com/spaceclub/global/mail/repository/MailTrackerRepository.java
@@ -1,0 +1,12 @@
+package com.spaceclub.global.mail.repository;
+
+import com.spaceclub.global.mail.domain.MailTracker;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MailTrackerRepository extends JpaRepository<MailTracker, Long> {
+
+    Page<MailTracker> findAllByIsSentFalse(Pageable pageable);
+
+}


### PR DESCRIPTION
### 💠 Jira 티켓 링크
- [SKRB-419](https://space-club.atlassian.net/jira/software/projects/SKRB/boards/1?assignee=5fa0f9c5248fc30078abb600&selectedIssue=SKRB-419)
  <br>

### 🖥️ 작업 내용

- 비동기로 다른 thread에서 실행 되도록 구현
- Event를 publish / listen 통해서 의존성 제거
- `@Transactional` 전파 레벨을 REQUIRES_NEW로 설정해서 별도의 트랜잭션에서 mail tracker db에 저장 및 기록

<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [ ] Postman QA 여부 -> 불필요
  <br>

### 📢 리뷰어 전달 사항
- develop에도 mail tracker 테이블 생성 했습니다.
- 마지막 두 커밋만 보면 됩니다.


[SKRB-419]: https://space-club.atlassian.net/browse/SKRB-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ