### PR TITLE
fix: 모집 공고 일정 생성 시 recruitmentLimit 저장 안되는 이슈 해결

### DIFF
--- a/src/main/java/com/spaceclub/event/domain/EventInfo.java
+++ b/src/main/java/com/spaceclub/event/domain/EventInfo.java
@@ -102,6 +102,7 @@ public class EventInfo {
                 .posterImageName(posterImageName)
                 .activityArea(this.activityArea)
                 .recruitmentTarget(this.recruitmentTarget)
+                .recruitmentLimit(this.recruitmentLimit)
                 .endDateTime(this.endDateTime)
                 .dues(this.dues)
                 .build();


### PR DESCRIPTION
### 🖥️ 작업 내용
- 모집 공고 일정 생성 시 recruitmentLimit 저장 안되는 이슈 해결
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
