### PR TITLE
feat, fix: s3 url관련 null 처리 및 행사 배너 조회 api에서 클럽 일정 행사 제외하도록 구현

### DIFF
--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -149,7 +149,7 @@ public class EventController {
         List<Event> events = eventService.getBanner(now, BANNER_LIMIT);
 
         List<EventBannerResponse> bannerResponses = events.stream()
-                .map(EventBannerResponse::from)
+                .map(event -> EventBannerResponse.from(event, s3Properties.url()))
                 .toList();
 
         return ResponseEntity.ok(bannerResponses);

--- a/src/main/java/com/spaceclub/event/controller/dto/EventBannerResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventBannerResponse.java
@@ -9,10 +9,10 @@ public record EventBannerResponse(
         EventInfoResponse eventInfo
 ) {
 
-    public static EventBannerResponse from(Event event) {
+    public static EventBannerResponse from(Event event, String bucketUrl) {
         ClubInfoResponse clubInfoResponse = new ClubInfoResponse(
-                event.getClubName(),
-                event.getClubCoverImageName()
+                event.getClubCoverImageName() == null ? null : bucketUrl + event.getClubCoverImageName(),
+                event.getClubName()
         );
         EventInfoResponse eventInfoResponse = new EventInfoResponse(
                 event.getId(),

--- a/src/main/java/com/spaceclub/event/controller/dto/EventOverviewGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventOverviewGetResponse.java
@@ -14,7 +14,7 @@ public record EventOverviewGetResponse(Long id,
                 event.getId(),
                 new EventInfoResponse(
                         event.getTitle(),
-                        event.getPosterImageName() != null ? bucketUrl + event.getPosterImageName() : null,
+                        event.getPosterImageName() == null ? null : bucketUrl + event.getPosterImageName(),
                         event.getLocation(),
                         event.getStartDate(),
                         event.getStartTime(),
@@ -24,8 +24,8 @@ public record EventOverviewGetResponse(Long id,
                 ),
                 new ClubInfoResponse(
                         event.getClubName(),
-                        bucketUrl + event.getClubLogoImageName(),
-                        bucketUrl + event.getClubCoverImageName()
+                        event.getClubLogoImageName() == null ? null : bucketUrl + event.getClubLogoImageName(),
+                        event.getClubCoverImageName() == null ? null : bucketUrl + event.getClubLogoImageName()
                 )
         );
     }

--- a/src/main/java/com/spaceclub/event/controller/dto/EventSearchOverviewGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventSearchOverviewGetResponse.java
@@ -24,7 +24,7 @@ public record EventSearchOverviewGetResponse(Long id,
                 ),
                 new ClubInfoResponse(
                         event.getClubName(),
-                        bucketUrl + event.getClubLogoImageName()
+                        event.getClubCoverImageName() == null ? null : bucketUrl + event.getClubLogoImageName()
                 )
         );
     }

--- a/src/main/java/com/spaceclub/event/repository/EventRepository.java
+++ b/src/main/java/com/spaceclub/event/repository/EventRepository.java
@@ -29,6 +29,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("select e from Event e join fetch Bookmark b on e.id = b.eventId where b.userId = :userId")
     Page<Event> findAllBookmarkedEventPages(@Param("userId") Long userId, Pageable pageable);
 
-    Page<Event> findAllByFormInfo_FormCloseDateTimeGreaterThan(LocalDateTime now, PageRequest pageable);
+    Page<Event> findAllByCategoryNotAndFormInfo_FormCloseDateTimeGreaterThan(EventCategory category, LocalDateTime now, Pageable pageable);
 
 }

--- a/src/main/java/com/spaceclub/event/service/EventService.java
+++ b/src/main/java/com/spaceclub/event/service/EventService.java
@@ -170,7 +170,7 @@ public class EventService implements EventProvider {
     public List<Event> getBanner(LocalDateTime now, int limit) {
         PageRequest pageable = PageRequest.of(0, limit, Sort.by(ASC, "formInfo.formCloseDateTime"));
 
-        return eventRepository.findAllByFormInfo_FormCloseDateTimeGreaterThan(now, pageable).getContent();
+        return eventRepository.findAllByCategoryNotAndFormInfo_FormCloseDateTimeGreaterThan(CLUB, now, pageable).getContent();
     }
 
     @Override

--- a/src/main/java/com/spaceclub/event/service/vo/ClubEventOverviewGetInfo.java
+++ b/src/main/java/com/spaceclub/event/service/vo/ClubEventOverviewGetInfo.java
@@ -35,7 +35,7 @@ public record ClubEventOverviewGetInfo(
                 event.getLocation(),
                 event.getCategory().equals(EventCategory.CLUB) ? "CLUB" : "ALL",
                 event.getClubName(),
-                bucketUrl + event.getClubLogoImageName(),
+                event.getClubLogoImageName() == null ? null : bucketUrl + event.getClubLogoImageName(),
                 userProfile.username(),
                 userProfile.profileImageUrl()
         );

--- a/src/main/java/com/spaceclub/invite/controller/dto/ClubRequestToJoinResponse.java
+++ b/src/main/java/com/spaceclub/invite/controller/dto/ClubRequestToJoinResponse.java
@@ -21,7 +21,7 @@ public record ClubRequestToJoinResponse(
                 .name(club.getName())
                 .info(club.getInfo())
                 .memberCount(memberCount)
-                .logoImageUrl(bucketUrl + club.getLogoImageName())
+                .logoImageUrl(club.getLogoImageName() == null ? null : bucketUrl + club.getLogoImageName())
                 .build();
     }
 


### PR DESCRIPTION
### 🖥️ 작업 내용
- s3 url관련 null 처리
- 행사 배너 조회 api에서 클럽 일정 행사 제외하도록 구현
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
@juno-junho 준호님! s3 url관련 null처리 이슈 발견해서 해결하다가 배너 조회 쪽 오류도 수정헀습니다!
확인 부탁드릴게요~!