### PR TITLE
feat: 유저의 신청된 행사 조회, 제출된 폼 조회 api에 ticketCount 추가

### DIFF
--- a/src/main/java/com/spaceclub/event/domain/EventUser.java
+++ b/src/main/java/com/spaceclub/event/domain/EventUser.java
@@ -109,4 +109,8 @@ public class EventUser extends BaseTimeEntity {
         return createdAt.format(formatter);
     }
 
+    public EventCategory getEventCategory() {
+        return event.getCategory();
+    }
+
 }

--- a/src/main/java/com/spaceclub/event/service/UserEventProvider.java
+++ b/src/main/java/com/spaceclub/event/service/UserEventProvider.java
@@ -8,4 +8,6 @@ public interface UserEventProvider {
 
     Page<EventPageInfo> findAllEventPages(Long userId, Pageable pageable);
 
+    int getTicketCount(Long eventId, Long userId);
+
 }

--- a/src/main/java/com/spaceclub/event/service/UserEventService.java
+++ b/src/main/java/com/spaceclub/event/service/UserEventService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static com.spaceclub.event.EventExceptionMessage.EVENT_NOT_APPLIED;
 import static java.util.stream.Collectors.toMap;
 
 @Service
@@ -43,6 +44,15 @@ public class UserEventService implements UserEventProvider {
                 .toList();
 
         return new PageImpl<>(eventPageInfos, eventPages.getPageable(), eventPages.getTotalElements());
+    }
+
+    @Override
+    public int getTicketCount(Long eventId, Long userId) {
+        EventUser eventUser = eventUserRepository.findByEventIdAndUserId(eventId, userId).orElseThrow(
+                () -> new IllegalStateException(EVENT_NOT_APPLIED.toString())
+        );
+
+        return eventUser.getTicketCount();
     }
 
 }

--- a/src/main/java/com/spaceclub/event/service/vo/EventPageInfo.java
+++ b/src/main/java/com/spaceclub/event/service/vo/EventPageInfo.java
@@ -1,6 +1,7 @@
 package com.spaceclub.event.service.vo;
 
 import com.spaceclub.event.domain.Event;
+import com.spaceclub.event.domain.EventCategory;
 import com.spaceclub.event.domain.EventUser;
 import com.spaceclub.event.domain.ParticipationStatus;
 
@@ -8,6 +9,7 @@ import java.time.LocalDate;
 
 public record EventPageInfo(
         Long id,
+        EventCategory category,
         String title,
         String location,
         String clubName,
@@ -19,6 +21,7 @@ public record EventPageInfo(
     public static EventPageInfo from(Event event, EventUser eventUser, String bucketUrl) {
         return new EventPageInfo(
                 event.getId(),
+                event.getCategory(),
                 event.getTitle(),
                 event.getLocation(),
                 event.getClubName(),

--- a/src/main/java/com/spaceclub/form/controller/dto/FormSubmitGetResponse.java
+++ b/src/main/java/com/spaceclub/form/controller/dto/FormSubmitGetResponse.java
@@ -6,10 +6,13 @@ import com.spaceclub.form.domain.Form;
 import com.spaceclub.form.domain.FormAnswer;
 import com.spaceclub.form.domain.FormOption;
 import com.spaceclub.form.service.vo.FormSubmitGetInfo;
+import lombok.Builder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 
 import java.util.List;
+
+import static com.spaceclub.event.domain.EventCategory.SHOW;
 
 public record FormSubmitGetResponse(
         FormInfoResponse formInfo,
@@ -42,7 +45,13 @@ public record FormSubmitGetResponse(
                             .map(formAnswer -> new UserFormOptionResponse(formAnswer.getOptionTitle(), formAnswer.getContent()))
                             .toList();
 
-                    return new UserFormResponse(userId, options, new ParticipationResponse(eventUser.getStatus(), eventUser.getParticipationDateTime()));
+                    return UserFormResponse.builder()
+                            .userId(userId)
+                            .options(options)
+                            .participation(new ParticipationResponse(eventUser.getStatus(), eventUser.getParticipationDateTime()))
+                            .ticketCount(SHOW.equals(eventUser.getEventCategory()) ? eventUser.getTicketCount() : null)
+                            .build();
+
                 })
                 .toList();
 
@@ -57,8 +66,14 @@ public record FormSubmitGetResponse(
     private record UserFormResponse(
             Long userId,
             List<UserFormOptionResponse> options,
-            ParticipationResponse participation
+            ParticipationResponse participation,
+            Integer ticketCount
     ) {
+
+        @Builder
+        private UserFormResponse {
+
+        }
 
     }
 

--- a/src/main/java/com/spaceclub/user/controller/ContentController.java
+++ b/src/main/java/com/spaceclub/user/controller/ContentController.java
@@ -20,12 +20,15 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.spaceclub.event.domain.EventCategory.SHOW;
+
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class ContentController {
 
     private final UserEventProvider userEventProvider;
+
     private final ClubProvider clubService;
 
     @GetMapping("/events")
@@ -33,7 +36,10 @@ public class ContentController {
         Page<EventPageInfo> eventPages = userEventProvider.findAllEventPages(jwtUser.id(), pageable);
 
         List<UserEventGetResponse> eventGetResponse = eventPages.getContent().stream()
-                .map(UserEventGetResponse::from)
+                .map(event -> UserEventGetResponse.from(
+                        event,
+                        SHOW.equals(event.category()) ? userEventProvider.getTicketCount(event.id(), jwtUser.id()) : null
+                ))
                 .toList();
 
         return new PageResponse<>(eventGetResponse, eventPages);

--- a/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
+++ b/src/main/java/com/spaceclub/user/controller/dto/UserEventGetResponse.java
@@ -12,10 +12,11 @@ public record UserEventGetResponse(
         String clubName,
         String posterImageUrl,
         LocalDate startDate,
-        ParticipationStatus participationStatus
+        ParticipationStatus participationStatus,
+        Integer ticketCount
 ) {
 
-    public static UserEventGetResponse from(EventPageInfo event) {
+    public static UserEventGetResponse from(EventPageInfo event, Integer ticketCount) {
         return new UserEventGetResponse(
                 event.id(),
                 event.title(),
@@ -23,7 +24,8 @@ public record UserEventGetResponse(
                 event.clubName(),
                 event.posterImageUrl(),
                 event.startDate(),
-                event.participationStatus()
+                event.participationStatus(),
+                ticketCount
         );
     }
 

--- a/src/test/java/com/spaceclub/event/EventTestFixture.java
+++ b/src/test/java/com/spaceclub/event/EventTestFixture.java
@@ -121,6 +121,7 @@ public class EventTestFixture {
                 .status(ParticipationStatus.PENDING)
                 .userId(1L)
                 .event(event1())
+                .ticketCount(5)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/test/java/com/spaceclub/form/controller/SubmitControllerTest.java
+++ b/src/test/java/com/spaceclub/form/controller/SubmitControllerTest.java
@@ -127,6 +127,7 @@ class SubmitControllerTest {
                                         fieldWithPath("userForms[].participation").type(OBJECT).description("신청 정보"),
                                         fieldWithPath("userForms[].participation.status").type(STRING).description("신청 상태"),
                                         fieldWithPath("userForms[].participation.dateTime").type(STRING).description("신청 날짜 및 시각"),
+                                        fieldWithPath("userForms[].ticketCount").type(NUMBER).description("신청한 티켓 수"),
                                         fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),
                                         fieldWithPath("pageData.first").type(BOOLEAN).description("첫 페이지 여부"),
                                         fieldWithPath("pageData.last").type(BOOLEAN).description("마지막 페이지 여부"),

--- a/src/test/java/com/spaceclub/user/controller/ContentControllerTest.java
+++ b/src/test/java/com/spaceclub/user/controller/ContentControllerTest.java
@@ -125,6 +125,7 @@ class ContentControllerTest {
                                         fieldWithPath("data[].posterImageUrl").type(STRING).description("포스터 URL"),
                                         fieldWithPath("data[].startDate").type(STRING).description("이벤트 시작일"),
                                         fieldWithPath("data[].participationStatus").type(STRING).description("이벤트 신청 상태"),
+                                        fieldWithPath("data[].ticketCount").type(NUMBER).description("신청한 티켓 수"),
                                         fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),
                                         fieldWithPath("pageData.first").type(BOOLEAN).description("첫 페이지 여부"),
                                         fieldWithPath("pageData.last").type(BOOLEAN).description("마지막 페이지 여부"),


### PR DESCRIPTION
### 🖥️ 작업 내용
- 유저의 신청된 행사 조회, 제출된 폼 조회 api에 ticketCount 추가
  - 공연의 경우 저장된 ticketCount, 나머지 카테고리의 경우 null 넣기 (나머지 카테고리는 출력할 필요가 없기 때문)
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
