### PR TITLE
feat: 모든 행사 정렬 추가 및 행사 최소 정원 0으로 변경

### DIFF
--- a/src/main/java/com/spaceclub/event/controller/EventController.java
+++ b/src/main/java/com/spaceclub/event/controller/EventController.java
@@ -74,13 +74,11 @@ public class EventController {
 
     @GetMapping
     public ResponseEntity<PageResponse<EventOverviewGetResponse, Event>> getAll(@RequestParam EventCategory category,
-                                                                                @RequestParam(required = false) Boolean isEnded,
                                                                                 @PageableDefault(size = 1000) Pageable pageable) {
+
         Page<Event> events = eventService.getAll(category, pageable);
 
-        List<EventOverviewGetResponse> responses = events.getContent()
-                .stream()
-                .filter(event -> isEnded == null || event.isEventEnded() == isEnded)
+        List<EventOverviewGetResponse> responses = events.stream()
                 .map(event -> EventOverviewGetResponse.from(event, s3Properties.url()))
                 .toList();
 

--- a/src/main/java/com/spaceclub/event/controller/dto/EventOverviewGetResponse.java
+++ b/src/main/java/com/spaceclub/event/controller/dto/EventOverviewGetResponse.java
@@ -24,8 +24,7 @@ public record EventOverviewGetResponse(Long id,
                 ),
                 new ClubInfoResponse(
                         event.getClubName(),
-                        event.getClubLogoImageName() == null ? null : bucketUrl + event.getClubLogoImageName(),
-                        event.getClubCoverImageName() == null ? null : bucketUrl + event.getClubLogoImageName()
+                        event.getClubLogoImageName() == null ? null : bucketUrl + event.getClubLogoImageName()
                 )
         );
     }
@@ -45,8 +44,7 @@ public record EventOverviewGetResponse(Long id,
 
     private record ClubInfoResponse(
             String name,
-            String logoImageUrl,
-            String coverImageUrl
+            String logoImageUrl
     ) {
 
     }

--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -182,6 +182,10 @@ public class Event extends BaseTimeEntity {
         return eventInfo.getStartDateTime();
     }
 
+    public LocalDateTime getEndDateTime() {
+        return eventInfo.getEndDateTime();
+    }
+
     public String getLocation() {
         if (eventInfo.getLocation() == null) return null;
         return eventInfo.getLocation();
@@ -201,10 +205,6 @@ public class Event extends BaseTimeEntity {
 
     public String getClubCoverImageName() {
         return club.getCoverImageName();
-    }
-
-    public LocalDateTime getFormOpenDateTime() {
-        return formInfo.getFormOpenDateTime();
     }
 
     public LocalDateTime getFormCloseDateTime() {

--- a/src/main/java/com/spaceclub/event/domain/Event.java
+++ b/src/main/java/com/spaceclub/event/domain/Event.java
@@ -207,6 +207,10 @@ public class Event extends BaseTimeEntity {
         return club.getCoverImageName();
     }
 
+    public LocalDateTime getFormOpenDateTime() {
+        return formInfo.getFormOpenDateTime();
+    }
+
     public LocalDateTime getFormCloseDateTime() {
         return formInfo.getFormCloseDateTime();
     }

--- a/src/main/java/com/spaceclub/event/domain/TicketInfo.java
+++ b/src/main/java/com/spaceclub/event/domain/TicketInfo.java
@@ -19,7 +19,7 @@ public class TicketInfo {
 
     private static final Integer MAX_TICKET_COUNT_MAX_COUNT = 999;
 
-    private static final Integer COST_MIN_LENGTH = 1;
+    private static final Integer COST_MIN_LENGTH = 0;
 
     private static final Integer COST_MAX_LENGTH = 1_000_000;
 

--- a/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
+++ b/src/test/java/com/spaceclub/event/controller/EventControllerTest.java
@@ -873,7 +873,6 @@ class EventControllerTest {
         // when
         ResultActions actions = mvc.perform(get("/api/v1/events")
                 .param("category", "SHOW")
-                .param("isEnded", "false")
                 .param("page", "1")
                 .param("size", "3")
                 .param("sort", "id,asc")
@@ -894,7 +893,6 @@ class EventControllerTest {
                         preprocessResponse(prettyPrint()),
                         queryParameters(
                                 parameterWithName("category").description("행사 카테고리 (ex. SHOW, RECRUITMENT, PROMOTION, CLUB)"),
-                                parameterWithName("isEnded").optional().description("행사 종료 여부"),
                                 parameterWithName("page").optional().description("페이지"),
                                 parameterWithName("size").optional().description("페이지 내 개수"),
                                 parameterWithName("sort").optional().description("정렬 방법(ex. id,desc)")
@@ -914,7 +912,6 @@ class EventControllerTest {
                                 fieldWithPath("data[].clubInfo").type(OBJECT).description("클럽 정보"),
                                 fieldWithPath("data[].clubInfo.name").type(STRING).description("클럽 명"),
                                 fieldWithPath("data[].clubInfo.logoImageUrl").type(STRING).description("클럽 이미지 Url"),
-                                fieldWithPath("data[].clubInfo.coverImageUrl").type(STRING).description("클럽 커버 이미지 Url"),
                                 fieldWithPath("pageData").type(OBJECT).description("페이지 정보"),
                                 fieldWithPath("pageData.first").type(BOOLEAN).description("첫 페이지 여부"),
                                 fieldWithPath("pageData.last").type(BOOLEAN).description("마지막 페이지 여부"),

--- a/src/test/java/com/spaceclub/event/domain/TicketInfoTest.java
+++ b/src/test/java/com/spaceclub/event/domain/TicketInfoTest.java
@@ -18,7 +18,7 @@ class TicketInfoTest {
         assertThat(ticketInfo()).isNotNull();
     }
 
-    @ValueSource(ints = {0, 1000001})
+    @ValueSource(ints = {-1, 1000001})
     @ParameterizedTest(name = "{index}. cost : [{arguments}]")
     void 비용이_유효하지_않으면_생성에_실패한다(int cost) {
         assertThatThrownBy(() ->


### PR DESCRIPTION
### 🖥️ 작업 내용
- 모든 행사 조회 안쓰는 컬럼 제거 및 정렬 추가
- 정원 최소 인원 수 0으로 변경
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
