### PR TITLE
feat: 행사 배너 api 신청 가능한 행사만 나오도록 수정

### DIFF
--- a/src/main/java/com/spaceclub/event/repository/EventRepository.java
+++ b/src/main/java/com/spaceclub/event/repository/EventRepository.java
@@ -4,7 +4,6 @@ import com.spaceclub.event.domain.Event;
 import com.spaceclub.event.domain.EventCategory;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -17,6 +16,7 @@ import java.util.Optional;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Event> findWithLockById(Long id);
 
@@ -29,6 +29,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("select e from Event e join fetch Bookmark b on e.id = b.eventId where b.userId = :userId")
     Page<Event> findAllBookmarkedEventPages(@Param("userId") Long userId, Pageable pageable);
 
-    Page<Event> findAllByCategoryNotAndFormInfo_FormCloseDateTimeGreaterThan(EventCategory category, LocalDateTime now, Pageable pageable);
+    Page<Event> findAllByCategoryNotAndFormInfo_FormCloseDateTimeGreaterThanAndFormInfo_FormOpenDateTimeLessThan(EventCategory category, LocalDateTime closeDate, LocalDateTime openDate, Pageable pageable);
 
 }

--- a/src/main/java/com/spaceclub/event/service/EventService.java
+++ b/src/main/java/com/spaceclub/event/service/EventService.java
@@ -192,7 +192,7 @@ public class EventService implements EventProvider {
     public List<Event> getBanner(LocalDateTime now, int limit) {
         PageRequest pageable = PageRequest.of(0, limit, Sort.by(ASC, "formInfo.formCloseDateTime"));
 
-        return eventRepository.findAllByCategoryNotAndFormInfo_FormCloseDateTimeGreaterThan(CLUB, now, pageable).getContent();
+        return eventRepository.findAllByCategoryNotAndFormInfo_FormCloseDateTimeGreaterThanAndFormInfo_FormOpenDateTimeLessThan(CLUB, now, now, pageable).getContent();
     }
 
     @Override


### PR DESCRIPTION
### 🖥️ 작업 내용
- 행사 배너 api 신청 가능한 행사만 나오도록 수정
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
