### PR TITLE
feat: 금칙어 적용시 어노테이션 통해 validation 하는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/spaceclub/club/controller/dto/ClubUpdateRequest.java
+++ b/src/main/java/com/spaceclub/club/controller/dto/ClubUpdateRequest.java
@@ -1,7 +1,6 @@
 package com.spaceclub.club.controller.dto;
 
 import com.spaceclub.club.domain.Club;
-import com.spaceclub.global.bad_word_filter.BadWordFilter;
 
 public record ClubUpdateRequest(
         String name,

--- a/src/main/java/com/spaceclub/global/bad_word_filter/BadWord.java
+++ b/src/main/java/com/spaceclub/global/bad_word_filter/BadWord.java
@@ -1,0 +1,24 @@
+package com.spaceclub.global.bad_word_filter;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = BadWordFilter.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BadWord {
+
+    String message() default "비속어가 발견 되었습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/spaceclub/global/bad_word_filter/BadWordFilter.java
+++ b/src/main/java/com/spaceclub/global/bad_word_filter/BadWordFilter.java
@@ -5,6 +5,8 @@ import com.googlecode.concurrenttrees.radixinverted.ConcurrentInvertedRadixTree;
 import com.googlecode.concurrenttrees.radixinverted.InvertedRadixTree;
 import com.spaceclub.global.config.BadWordConfig;
 import jakarta.annotation.PostConstruct;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,6 +16,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
 
 import static com.spaceclub.global.bad_word_filter.BadWordExceptionMessage.BAD_WORD_DETECTED;
 import static com.spaceclub.global.bad_word_filter.BadWordExceptionMessage.FAIL_BAD_WORD_SETUP;
@@ -21,7 +25,7 @@ import static com.spaceclub.global.bad_word_filter.BadWordExceptionMessage.FAIL_
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class BadWordFilter {
+public class BadWordFilter implements ConstraintValidator<BadWord, String> {
 
     private final BadWordConfig config;
 
@@ -31,9 +35,7 @@ public class BadWordFilter {
     private void setup() {
         try {
             List<String> badWords = Files.readAllLines(Paths.get(config.path()));
-            for (String badWord : badWords) {
-                trie.put(badWord, badWord);
-            }
+            badWords.forEach(badword -> trie.put(badword, badword));
         } catch (IOException e) {
             throw new IllegalStateException(FAIL_BAD_WORD_SETUP.toString());
         }
@@ -50,6 +52,22 @@ public class BadWordFilter {
             log.info("비속어 감지: {}", filteredWords);
             throw new IllegalArgumentException(BAD_WORD_DETECTED.toString());
         }
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+
+        // 성능 테스트 해보기 (parallelStream)
+        Spliterator<String> searchedBadWords = trie.getValuesForKeysContainedIn(value).spliterator();
+        List<String> filteredWords = StreamSupport.stream(searchedBadWords, true)
+                .toList();
+
+        if (!filteredWords.isEmpty()) {
+            log.info("비속어 감지: {}", filteredWords);
+            throw new IllegalArgumentException(BAD_WORD_DETECTED.toString());
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
### 🖥️ 작업 내용

dto에서 validation annotation 통해 금칙어 검증을 할 수 있도록 변경했습니다.
적용만 하면 됩니다.

<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부

  <br>

마지막 한 커밋만 보면 됩니다.

