### PR TITLE
feat: @DirtiesContext 제거를 통한 테스트 개선

### DIFF
--- a/src/main/java/com/spaceclub/event/repository/EventRepository.java
+++ b/src/main/java/com/spaceclub/event/repository/EventRepository.java
@@ -9,13 +9,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-@Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/test/java/com/spaceclub/club/repository/ClubUserRepositoryTest.java
+++ b/src/test/java/com/spaceclub/club/repository/ClubUserRepositoryTest.java
@@ -4,12 +4,14 @@ import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.domain.ClubUser;
 import com.spaceclub.club.domain.ClubUserRole;
 import com.spaceclub.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,18 +26,20 @@ import static com.spaceclub.user.UserTestFixture.user2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@DataJpaTest
+@SpringBootTest
+@Transactional
 @DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class ClubUserRepositoryTest {
 
     @Autowired
     private ClubUserRepository clubUserRepository;
-
     @Autowired
     private ClubRepository clubRepository;
-
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private EntityManager entityManager;
+
 
     @BeforeEach
     void setUp() {
@@ -44,8 +48,13 @@ class ClubUserRepositoryTest {
         clubUserRepository.save(club1User1Manager());
     }
 
+    @AfterEach
+    void resetAutoIncrementId() {
+        entityManager.createNativeQuery("ALTER TABLE CLUB ALTER COLUMN CLUB_ID RESTART WITH 1")
+                .executeUpdate();
+    }
+
     @Test
-    @DirtiesContext
     void 클럽_id로_클럽유저_조회에_성공한다() {
         // given
         clubRepository.save(club2());
@@ -60,7 +69,6 @@ class ClubUserRepositoryTest {
 
 
     @Test
-    @DirtiesContext
     void 클럽의_유저_조회에_성공한다() {
         // when
         Optional<ClubUser> getClubUser = clubUserRepository.findByClub_IdAndUserId(club1().getId(), user1().getId());
@@ -74,7 +82,6 @@ class ClubUserRepositoryTest {
     }
 
     @Test
-    @DirtiesContext
     void 클럽의_권한에_따른_인원수_조회에_성공한다() {
         // given
         userRepository.save(user2());
@@ -88,7 +95,6 @@ class ClubUserRepositoryTest {
     }
 
     @Test
-    @DirtiesContext
     void 유저에_따른_클럽유저_조회에_성공한다() {
         // given
         clubRepository.save(club2());

--- a/src/test/java/com/spaceclub/event/repository/EventRepositoryTest.java
+++ b/src/test/java/com/spaceclub/event/repository/EventRepositoryTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.List;
 
@@ -21,17 +20,14 @@ import static com.spaceclub.event.EventTestFixture.event1;
 import static com.spaceclub.event.EventTestFixture.showEvent;
 import static com.spaceclub.user.UserTestFixture.user1;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @DataJpaTest
-@DirtiesContext
 @DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class EventRepositoryTest {
 
     @Autowired
     private EventRepository eventRepository;
-
     @Autowired
     private ClubRepository clubRepository;
 
@@ -47,13 +43,8 @@ class EventRepositoryTest {
         List<Event> events = eventPages.getContent();
 
         // then
-        assertAll(
-                () -> assertThat(eventPages.getTotalElements())
-                        .isEqualTo(2),
-                () -> assertThat(events).allSatisfy(event -> {
-                    assertThat(event.getClub()).isEqualTo(club1());
-                })
-        );
+        assertThat(eventPages.getTotalElements()).isEqualTo(2);
+        events.forEach(event -> assertThat(event.getClub()).isEqualTo(club1()));
     }
 
 }

--- a/src/test/java/com/spaceclub/event/repository/EventUserRepositoryTest.java
+++ b/src/test/java/com/spaceclub/event/repository/EventUserRepositoryTest.java
@@ -9,17 +9,19 @@ import com.spaceclub.event.domain.ParticipationStatus;
 import com.spaceclub.user.domain.Provider;
 import com.spaceclub.user.domain.User;
 import com.spaceclub.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -30,24 +32,30 @@ import static com.spaceclub.user.domain.Status.NOT_REGISTERED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.data.domain.Sort.Direction.DESC;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
-@DataJpaTest
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+@Transactional
+@SpringBootTest
 @DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class EventUserRepositoryTest {
 
     @Autowired
     private EventUserRepository eventUserRepository;
-
     @Autowired
     private EventRepository eventRepository;
-
     @Autowired
     private UserRepository userRepository;
-
     @Autowired
     private ClubRepository clubRepository;
+    @Autowired
+    private EntityManager entityManager;
+
+    @AfterEach
+    void resetAutoIncrementId() {
+        entityManager.createNativeQuery("ALTER TABLE EVENT ALTER COLUMN EVENT_ID RESTART WITH 1")
+                .executeUpdate();
+        entityManager.createNativeQuery("ALTER TABLE CLUB ALTER COLUMN CLUB_ID RESTART WITH 1")
+                .executeUpdate();
+    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/spaceclub/notification/mail/repository/TemplateNameRepositoryTest.java
+++ b/src/test/java/com/spaceclub/notification/mail/repository/TemplateNameRepositoryTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -20,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
 class TemplateNameRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/spaceclub/user/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/spaceclub/user/repository/BookmarkRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.spaceclub.user.repository;
 
+import com.spaceclub.SpaceClubCustomDisplayNameGenerator;
 import com.spaceclub.club.domain.Club;
 import com.spaceclub.club.repository.ClubRepository;
 import com.spaceclub.event.domain.Event;
@@ -8,27 +9,28 @@ import com.spaceclub.user.domain.Bookmark;
 import com.spaceclub.user.domain.Provider;
 import com.spaceclub.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.spaceclub.event.EventTestFixture.clubEvent;
 import static com.spaceclub.event.EventTestFixture.event1;
 import static com.spaceclub.event.EventTestFixture.showEvent;
-import static com.spaceclub.event.EventTestFixture.clubEvent;
 import static com.spaceclub.user.domain.Status.NOT_REGISTERED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.data.domain.Sort.Direction.DESC;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
-@DataJpaTest
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class BookmarkRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/spaceclub/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/spaceclub/user/repository/UserRepositoryTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,8 +17,8 @@ import static com.spaceclub.user.domain.Status.INACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@DataJpaTest
-@DirtiesContext
+@SpringBootTest
+@Transactional
 @DisplayNameGeneration(SpaceClubCustomDisplayNameGenerator.class)
 class UserRepositoryTest {
 


### PR DESCRIPTION
### 🖥️ 작업 내용
- DirtiesContext 제거를 통한 1초 645ms -> 1초388ms 로 성능 개선
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
  <br>
