### PR TITLE
[SKRR-26] feat: querydsl 설정 추가 및 게시글 및 댓글에서 유저 정보 조회 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### query dsl ###
+src/main/generated
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,17 @@ dependencies {
 	// monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// querydsl
+clean {
+	delete file('src/main/generated')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spaceclub/board/controller/PostController.java
+++ b/src/main/java/com/spaceclub/board/controller/PostController.java
@@ -1,10 +1,10 @@
 package com.spaceclub.board.controller;
 
-import com.spaceclub.board.controller.domain.Post;
 import com.spaceclub.board.controller.dto.PostRequest;
 import com.spaceclub.board.controller.dto.PostResponse;
 import com.spaceclub.board.controller.dto.PostUpdateRequest;
 import com.spaceclub.board.service.PostService;
+import com.spaceclub.board.service.vo.PostInfo;
 import com.spaceclub.global.Authenticated;
 import com.spaceclub.global.dto.PageResponse;
 import com.spaceclub.global.jwt.vo.JwtUser;
@@ -43,13 +43,13 @@ public class PostController {
     private final S3ImageUploader imageUploader;
 
     @GetMapping("/{clubId}")
-    public PageResponse<PostResponse, Post> getClubBoardPostsByPaging(
+    public PageResponse<PostResponse, PostInfo> getClubBoardPostsByPaging(
             @PageableDefault(sort = "id", direction = DESC) Pageable pageable,
             @PathVariable Long clubId
     ) {
-        Page<Post> postPages = postService.getClubBoardPostsByPaging(pageable, clubId);
+        Page<PostInfo> postPages = postService.getClubBoardPostsByPaging(pageable, clubId);
         List<PostResponse> posts = postPages.getContent().stream()
-                .map(PostResponse::from)
+                .map(post -> PostResponse.from(post, imageUploader.getBucketUrl()))
                 .toList();
 
         return new PageResponse<>(posts, postPages);
@@ -58,12 +58,11 @@ public class PostController {
     @GetMapping("/{clubId}/{postId}")
     public PostResponse getSingleClubBoardPost(
             @PathVariable Long clubId,
-
             @PathVariable Long postId
     ) {
-        Post post = postService.getClubBoardPost(clubId, postId);
+        PostInfo postInfo = postService.getClubBoardPost(clubId, postId);
 
-        return PostResponse.from(post);
+        return PostResponse.from(postInfo, imageUploader.getBucketUrl());
     }
 
     @PostMapping(value = "/{clubId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/spaceclub/board/controller/domain/Comment.java
+++ b/src/main/java/com/spaceclub/board/controller/domain/Comment.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
@@ -32,12 +34,22 @@ public class Comment extends BaseTimeEntity {
     private Long postId;
 
     @Builder
-    private Comment(Long id, String content, Long authorId, boolean isPrivate, Long postId) {
+    private Comment(
+            Long id,
+            String content,
+            Long authorId,
+            boolean isPrivate,
+            Long postId,
+            LocalDateTime createdAt,
+            LocalDateTime lastModifiedAt
+    ) {
         this.id = id;
         this.content = content;
         this.authorId = authorId;
         this.isPrivate = isPrivate;
         this.postId = postId;
+        this.createdAt = createdAt;
+        this.lastModifiedAt = lastModifiedAt;
     }
 
     public void updateComment(String content, boolean isPrivate) {

--- a/src/main/java/com/spaceclub/board/controller/domain/Post.java
+++ b/src/main/java/com/spaceclub/board/controller/domain/Post.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
@@ -36,14 +38,24 @@ public class Post extends BaseTimeEntity {
     private Long clubId;
 
     @Builder
-    private Post(Long id, String title, String content, String postImageUrl, Long authorId, Long clubId) {
+    private Post(
+            Long id,
+            String title,
+            String content,
+            String postImageUrl,
+            Long authorId,
+            Long clubId,
+            LocalDateTime createdAt,
+            LocalDateTime lastModifiedAt)
+    {
         this.id = id;
         this.title = title;
         this.content = content;
         this.postImageUrl = postImageUrl;
         this.authorId = authorId;
         this.clubId = clubId;
-
+        this.createdAt = createdAt;
+        this.lastModifiedAt = lastModifiedAt;
     }
 
     public void updatePost(String title, String content) {

--- a/src/main/java/com/spaceclub/board/controller/dto/CommentResponse.java
+++ b/src/main/java/com/spaceclub/board/controller/dto/CommentResponse.java
@@ -1,6 +1,6 @@
 package com.spaceclub.board.controller.dto;
 
-import com.spaceclub.board.controller.domain.Comment;
+import com.spaceclub.board.service.vo.CommentInfo;
 
 import java.time.LocalDateTime;
 
@@ -15,16 +15,16 @@ public record CommentResponse(
         boolean isPrivate
 ) {
 
-    public static CommentResponse of(Comment comment) {
+    public static CommentResponse of(CommentInfo commentInfo, String bucketUrl) {
         return new CommentResponse(
-                comment.getId(),
-                comment.getContent(),
-                comment.getAuthorId(),
-                "authorName",
-                "authorImageUrl",
-                LocalDateTime.of(2023, 12, 31, 12, 0, 0),
-                LocalDateTime.of(2023, 12, 31, 12, 0, 0),
-                comment.isPrivate()
+                commentInfo.commentId(),
+                commentInfo.content(),
+                commentInfo.authorId(),
+                commentInfo.author(),
+                commentInfo.authorImageUrl() == null ? null : bucketUrl + commentInfo.authorImageUrl(),
+                commentInfo.createdDate(),
+                commentInfo.lastModifiedDate(),
+                commentInfo.isPrivate()
         );
     }
 

--- a/src/main/java/com/spaceclub/board/controller/dto/PostResponse.java
+++ b/src/main/java/com/spaceclub/board/controller/dto/PostResponse.java
@@ -1,12 +1,9 @@
 package com.spaceclub.board.controller.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.spaceclub.board.controller.domain.Post;
-import lombok.Builder;
+import com.spaceclub.board.service.vo.PostInfo;
 
 import java.time.LocalDateTime;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostResponse(
         Long postId,
         String title,
@@ -19,21 +16,17 @@ public record PostResponse(
         LocalDateTime lastModifiedDate
 ) {
 
-    @Builder
-    public PostResponse {
-    }
-
-    public static PostResponse from(Post post) {
+    public static PostResponse from(PostInfo postInfo, String bucketUrl) {
         return new PostResponse(
-                post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                post.getAuthorId(),
-                "authorName",
-                "authorImageUrl",
-                post.getPostImageUrl(),
-                LocalDateTime.of(2023, 12, 31, 12, 0, 0),
-                LocalDateTime.of(2023, 12, 31, 12, 0, 0)
+                postInfo.postId(),
+                postInfo.title(),
+                postInfo.content(),
+                postInfo.authorId(),
+                postInfo.author(),
+                postInfo.authorImageUrl() == null ? null : bucketUrl + postInfo.authorImageUrl(),
+                postInfo.postImageUrl() == null ? null : bucketUrl + postInfo.postImageUrl(),
+                postInfo.createdDate(),
+                postInfo.lastModifiedDate()
         );
     }
 

--- a/src/main/java/com/spaceclub/board/repository/CommentRepository.java
+++ b/src/main/java/com/spaceclub/board/repository/CommentRepository.java
@@ -1,12 +1,12 @@
 package com.spaceclub.board.repository;
 
 import com.spaceclub.board.controller.domain.Comment;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    Slice<Comment> findByPostId(Long postId, Pageable pageable);
+    Page<Comment> findByPostId(Long postId, Pageable pageable);
 
 }

--- a/src/main/java/com/spaceclub/board/service/PostService.java
+++ b/src/main/java/com/spaceclub/board/service/PostService.java
@@ -4,7 +4,9 @@ import com.spaceclub.board.controller.domain.Post;
 import com.spaceclub.board.controller.dto.PostRequest;
 import com.spaceclub.board.controller.dto.PostUpdateRequest;
 import com.spaceclub.board.repository.PostRepository;
+import com.spaceclub.board.service.vo.PostInfo;
 import com.spaceclub.board.service.vo.PostUpdateCommand;
+import com.spaceclub.user.service.UserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,13 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserProvider userProvider;
 
-    public Page<Post> getClubBoardPostsByPaging(Pageable pageable, Long clubId) {
-        return postRepository.findByClubId(clubId, pageable);
+    public Page<PostInfo> getClubBoardPostsByPaging(Pageable pageable, Long clubId) {
+        return postRepository.findByClubId(clubId, pageable)
+                .map(post -> PostInfo.of(post, userProvider.getProfile(post.getAuthorId())));
     }
 
-    public Post getClubBoardPost(Long clubId, Long postId) {
-        return postRepository.findByClubIdAndId(clubId, postId).orElseThrow();
+    public PostInfo getClubBoardPost(Long clubId, Long postId) {
+        Post post = postRepository.findByClubIdAndId(clubId, postId).orElseThrow();
+
+        return PostInfo.of(post, userProvider.getProfile(post.getAuthorId()));
     }
 
     @Transactional

--- a/src/main/java/com/spaceclub/board/service/vo/CommentInfo.java
+++ b/src/main/java/com/spaceclub/board/service/vo/CommentInfo.java
@@ -1,0 +1,33 @@
+package com.spaceclub.board.service.vo;
+
+import com.spaceclub.board.controller.domain.Comment;
+import com.spaceclub.user.service.vo.UserProfile;
+
+import java.time.LocalDateTime;
+
+public record CommentInfo(
+        Long commentId,
+        String content,
+        Long authorId,
+        String author,
+        String authorImageUrl,
+        LocalDateTime createdDate,
+        LocalDateTime lastModifiedDate,
+        boolean isPrivate
+)
+{
+
+    public static CommentInfo of(Comment comment, UserProfile userProfile) {
+        return new CommentInfo(
+                comment.getId(),
+                comment.getContent(),
+                comment.getAuthorId(),
+                userProfile.username(),
+                userProfile.profileImageUrl(),
+                comment.getCreatedAt(),
+                comment.getLastModifiedAt(),
+                comment.isPrivate()
+        );
+    }
+
+}

--- a/src/main/java/com/spaceclub/board/service/vo/PostInfo.java
+++ b/src/main/java/com/spaceclub/board/service/vo/PostInfo.java
@@ -1,0 +1,34 @@
+package com.spaceclub.board.service.vo;
+
+import com.spaceclub.board.controller.domain.Post;
+import com.spaceclub.user.service.vo.UserProfile;
+
+import java.time.LocalDateTime;
+
+public record PostInfo(
+        Long postId,
+        String title,
+        String content,
+        Long authorId,
+        String author,
+        String authorImageUrl,
+        String postImageUrl,
+        LocalDateTime createdDate,
+        LocalDateTime lastModifiedDate
+)
+{
+
+    public static PostInfo of(Post post, UserProfile userProfile) {
+        return new PostInfo(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getAuthorId(),
+                userProfile.username(),
+                userProfile.profileImageUrl(),
+                post.getPostImageUrl(),
+                post.getCreatedAt(),
+                post.getLastModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/spaceclub/global/s3/S3ImageUploader.java
+++ b/src/main/java/com/spaceclub/global/s3/S3ImageUploader.java
@@ -71,4 +71,8 @@ public class S3ImageUploader {
         if (invalidExtension) throw new MultipartException(INVALID_FILE_EXTENSION.toString());
     }
 
+    public String getBucketUrl() {
+        return s3Properties.url();
+    }
+
 }


### PR DESCRIPTION
### 💠 Jira 티켓 링크


### 🖥️ 작업 내용
- 유저 정보 조회 기능 추가
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
