### PR TITLE
[SKRR-26] fix: user 이미지 url앞에 bucket url prefix가 중복으로 붙는 문제 해결

### DIFF
--- a/src/main/java/com/spaceclub/board/controller/dto/CommentResponse.java
+++ b/src/main/java/com/spaceclub/board/controller/dto/CommentResponse.java
@@ -21,7 +21,7 @@ public record CommentResponse(
                 commentInfo.content(),
                 commentInfo.authorId(),
                 commentInfo.author(),
-                commentInfo.authorImageUrl() == null ? null : bucketUrl + commentInfo.authorImageUrl(),
+                commentInfo.authorImageUrl(),
                 commentInfo.createdDate(),
                 commentInfo.lastModifiedDate(),
                 commentInfo.isPrivate()

--- a/src/main/java/com/spaceclub/board/controller/dto/PostResponse.java
+++ b/src/main/java/com/spaceclub/board/controller/dto/PostResponse.java
@@ -23,8 +23,8 @@ public record PostResponse(
                 postInfo.content(),
                 postInfo.authorId(),
                 postInfo.author(),
-                postInfo.authorImageUrl() == null ? null : bucketUrl + postInfo.authorImageUrl(),
-                postInfo.postImageUrl() == null ? null : bucketUrl + postInfo.postImageUrl(),
+                postInfo.authorImageUrl(),
+                postInfo.postImageUrl(bucketUrl),
                 postInfo.createdDate(),
                 postInfo.lastModifiedDate()
         );

--- a/src/main/java/com/spaceclub/board/service/vo/PostInfo.java
+++ b/src/main/java/com/spaceclub/board/service/vo/PostInfo.java
@@ -31,4 +31,12 @@ public record PostInfo(
                 post.getLastModifiedAt()
         );
     }
+
+    public String postImageUrl(String bucketUrl) {
+        if (postImageUrl == null) {
+            return null;
+        }
+        return bucketUrl + postImageUrl;
+    }
+
 }

--- a/src/test/java/com/spaceclub/board/controller/CommentControllerTest.java
+++ b/src/test/java/com/spaceclub/board/controller/CommentControllerTest.java
@@ -204,7 +204,7 @@ class CommentControllerTest {
                 .andExpect(jsonPath("$.content").value(comment.getContent()))
                 .andExpect(jsonPath("$.authorId").value(comment.getAuthorId()))
                 .andExpect(jsonPath("$.author").value(userProfile.username()))
-                .andExpect(jsonPath("$.authorImageUrl").value(bucketUrl + userProfile.profileImageUrl()))
+                .andExpect(jsonPath("$.authorImageUrl").value(userProfile.profileImageUrl()))
                 .andExpect(jsonPath("$.createdDate").value("2024-01-01T00:00:00"))
                 .andExpect(jsonPath("$.lastModifiedDate").value("2024-01-01T00:00:00"))
                 .andExpect(jsonPath("$.isPrivate").value(comment.isPrivate()))

--- a/src/test/java/com/spaceclub/board/controller/PostControllerTest.java
+++ b/src/test/java/com/spaceclub/board/controller/PostControllerTest.java
@@ -216,7 +216,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.content").value(post.getContent()))
                 .andExpect(jsonPath("$.authorId").value(post.getAuthorId()))
                 .andExpect(jsonPath("$.author").value(userProfile.username()))
-                .andExpect(jsonPath("$.authorImageUrl").value(bucketUrl + userProfile.profileImageUrl()))
+                .andExpect(jsonPath("$.authorImageUrl").value(userProfile.profileImageUrl()))
                 .andExpect(jsonPath("$.postImageUrl").value(bucketUrl + post.getPostImageUrl()))
                 .andExpect(jsonPath("$.createdDate").value("2024-01-01T00:00:00"))
                 .andExpect(jsonPath("$.lastModifiedDate").value("2024-01-01T00:00:00"))


### PR DESCRIPTION

### 🖥️ 작업 내용
- user 이미지 url앞에 bucket url prefix가 중복으로 붙는 문제 해결
- vo에서 getter를 재정의해 줌으로서 해결 (dto에서의 삼항연잔자 로직 제거 및 서비스 dto로 옮김)
<br>

### ✅ PR시 확인 사항
- [x] Linear History 여부
- [x] Postman QA 여부
  <br>

### 📢 리뷰어 전달 사항
